### PR TITLE
refactor: remove dead-code default templates from server.py

### DIFF
--- a/servers/vidcraft-server/server.py
+++ b/servers/vidcraft-server/server.py
@@ -284,18 +284,15 @@ def create_project_structure(
     if project_dir.exists():
         return f"Project '{slug}' already exists at {project_dir}"
 
-    # Create directories
+    template_path = Path(_plugin_root) / "templates" / "project.md"
+    if not template_path.exists():
+        return f"Template not found: {template_path}. Plugin installation may be corrupt."
+    template = template_path.read_text(encoding="utf-8")
+
     project_dir.mkdir(parents=True, exist_ok=True)
     (project_dir / "episodes").mkdir(exist_ok=True)
     (project_dir / "assets").mkdir(exist_ok=True)
     (project_dir / "research").mkdir(exist_ok=True)
-
-    # Load and fill project template
-    template_path = Path(_plugin_root) / "templates" / "project.md"
-    if template_path.exists():
-        template = template_path.read_text(encoding="utf-8")
-    else:
-        template = _default_project_template()
 
     readme_content = template.replace("{{title}}", title)
     readme_content = readme_content.replace("{{slug}}", slug)
@@ -344,6 +341,11 @@ def create_episode(
     if not project_dir.exists():
         return f"Project '{project_slug}' not found."
 
+    template_path = Path(_plugin_root) / "templates" / "episode.md"
+    if not template_path.exists():
+        return f"Template not found: {template_path}. Plugin installation may be corrupt."
+    template = template_path.read_text(encoding="utf-8")
+
     episodes_dir = project_dir / "episodes"
     episodes_dir.mkdir(exist_ok=True)
 
@@ -361,13 +363,6 @@ def create_episode(
     episode_dir.mkdir(parents=True, exist_ok=True)
     (episode_dir / "scenes").mkdir(exist_ok=True)
     (episode_dir / "assets").mkdir(exist_ok=True)
-
-    # Load and fill episode template
-    template_path = Path(_plugin_root) / "templates" / "episode.md"
-    if template_path.exists():
-        template = template_path.read_text(encoding="utf-8")
-    else:
-        template = _default_episode_template()
 
     content = template.replace("{{title}}", title)
     content = content.replace("{{number}}", str(number))
@@ -412,6 +407,11 @@ def create_scene(
     if not episode_dir.exists():
         return f"Episode '{episode_slug}' not found in project '{project_slug}'."
 
+    template_path = Path(_plugin_root) / "templates" / "scene.md"
+    if not template_path.exists():
+        return f"Template not found: {template_path}. Plugin installation may be corrupt."
+    template = template_path.read_text(encoding="utf-8")
+
     scenes_dir = episode_dir / "scenes"
     scenes_dir.mkdir(exist_ok=True)
 
@@ -425,13 +425,6 @@ def create_scene(
 
     if scene_file.exists():
         return f"Scene '{scene_slug}' already exists."
-
-    # Load and fill scene template
-    template_path = Path(_plugin_root) / "templates" / "scene.md"
-    if template_path.exists():
-        template = template_path.read_text(encoding="utf-8")
-    else:
-        template = _default_scene_template()
 
     content = template.replace("{{title}}", title)
     content = content.replace("{{number}}", str(number))
@@ -1477,103 +1470,6 @@ def get_plugin_version() -> str:
             "schema_version": "1.0.0",
         }
     )
-
-
-# ===========================================================================
-# Default templates (fallback if template files don't exist)
-# ===========================================================================
-
-
-def _default_project_template() -> str:
-    return """---
-title: "{{title}}"
-slug: "{{slug}}"
-video_type: "{{video_type}}"
-status: "Concept"
-platform: "{{platform}}"
-language: "{{language}}"
-target_audience: "{{target_audience}}"
-description: "{{description}}"
-created: "{{date}}"
-updated: "{{date}}"
----
-
-# {{title}}
-
-## Overview
-
-{{description}}
-
-## Target Audience
-
-{{target_audience}}
-
-## Episodes
-
-*No episodes created yet.*
-
-## Notes
-
-"""
-
-
-def _default_episode_template() -> str:
-    return """---
-title: "{{title}}"
-number: {{number}}
-slug: "{{slug}}"
-status: "Not Started"
-duration_target: "{{duration_target}}"
-platform: "{{platform}}"
-avatar: ""
-description: "{{description}}"
----
-
-# {{title}}
-
-## Description
-
-{{description}}
-
-## Scenes
-
-*No scenes created yet.*
-
-## Script Notes
-
-## Visual Notes
-
-"""
-
-
-def _default_scene_template() -> str:
-    return """---
-title: "{{title}}"
-number: {{number}}
-status: "Outline"
-visual_type: "{{visual_type}}"
-duration: "{{duration}}"
----
-
-# {{title}}
-
-## Narration
-
-*Write the spoken text for this scene here.*
-
-## On-Screen Text
-
-*Text overlays, titles, or captions shown on screen.*
-
-## Visual Direction
-
-*Describe what the viewer sees: avatar position, background, animations, transitions.*
-
-## Assets
-
-*List required assets: screenshots, images, logos, screen recordings.*
-
-"""
 
 
 # ===========================================================================

--- a/servers/vidcraft-server/server.py
+++ b/servers/vidcraft-server/server.py
@@ -286,7 +286,9 @@ def create_project_structure(
 
     template_path = Path(_plugin_root) / "templates" / "project.md"
     if not template_path.exists():
-        return f"Template not found: {template_path}. Plugin installation may be corrupt."
+        return (
+            f"Template not found: {template_path}. Plugin installation may be corrupt."
+        )
     template = template_path.read_text(encoding="utf-8")
 
     project_dir.mkdir(parents=True, exist_ok=True)
@@ -343,7 +345,9 @@ def create_episode(
 
     template_path = Path(_plugin_root) / "templates" / "episode.md"
     if not template_path.exists():
-        return f"Template not found: {template_path}. Plugin installation may be corrupt."
+        return (
+            f"Template not found: {template_path}. Plugin installation may be corrupt."
+        )
     template = template_path.read_text(encoding="utf-8")
 
     episodes_dir = project_dir / "episodes"
@@ -409,7 +413,9 @@ def create_scene(
 
     template_path = Path(_plugin_root) / "templates" / "scene.md"
     if not template_path.exists():
-        return f"Template not found: {template_path}. Plugin installation may be corrupt."
+        return (
+            f"Template not found: {template_path}. Plugin installation may be corrupt."
+        )
     template = template_path.read_text(encoding="utf-8")
 
     scenes_dir = episode_dir / "scenes"

--- a/tests/test_create_structures.py
+++ b/tests/test_create_structures.py
@@ -1,0 +1,182 @@
+"""Tests for create_project_structure / create_episode / create_scene template handling.
+
+These tests cover the template loading logic in server.py, specifically:
+- Template file present -> content is rendered with placeholders replaced
+- Template file missing -> actionable error is returned (no silent fallback)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Add server module to path
+_SERVER_DIR = Path(__file__).resolve().parent.parent / "servers" / "vidcraft-server"
+if str(_SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(_SERVER_DIR))
+
+import server  # noqa: E402
+
+
+@pytest.fixture
+def tmp_plugin_root(tmp_path: Path) -> Path:
+    """Create an isolated plugin root with an empty templates directory."""
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    (plugin / "templates").mkdir()
+    return plugin
+
+
+@pytest.fixture
+def patched_server(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_plugin_root: Path,
+    mock_config: dict[str, Any],
+) -> Any:
+    """Isolate server module: mock plugin root, config, and cache side effects."""
+    monkeypatch.setattr(server, "_plugin_root", str(tmp_plugin_root))
+    monkeypatch.setattr(server, "load_config", lambda: mock_config)
+    monkeypatch.setattr(server._cache, "invalidate", lambda: None)
+    return server
+
+
+def _write_template(plugin_root: Path, name: str, content: str) -> None:
+    (plugin_root / "templates" / name).write_text(content, encoding="utf-8")
+
+
+class TestCreateProjectStructureTemplate:
+    def test_renders_template_when_file_present(
+        self,
+        patched_server: Any,
+        tmp_plugin_root: Path,
+        tmp_content_root: Path,
+    ) -> None:
+        _write_template(
+            tmp_plugin_root,
+            "project.md",
+            "# {{title}}\nslug: {{slug}}\ntype: {{video_type}}\n",
+        )
+
+        result = patched_server.create_project_structure(
+            title="My Tutorial",
+            video_type="tutorial",
+        )
+
+        assert "created at" in result
+        readme = tmp_content_root / "projects" / "my-tutorial" / "README.md"
+        content = readme.read_text(encoding="utf-8")
+        assert "# My Tutorial" in content
+        assert "slug: my-tutorial" in content
+        assert "type: tutorial" in content
+        assert "{{title}}" not in content
+
+    def test_returns_actionable_error_when_template_missing(
+        self,
+        patched_server: Any,
+        tmp_content_root: Path,
+    ) -> None:
+        # No project.md written -> template file is missing
+        result = patched_server.create_project_structure(
+            title="Broken Project",
+            video_type="tutorial",
+        )
+
+        assert "Template not found" in result
+        assert "project.md" in result
+        # Project directory must not have a README.md written from fallback
+        readme = tmp_content_root / "projects" / "broken-project" / "README.md"
+        assert not readme.exists()
+
+
+class TestCreateEpisodeTemplate:
+    def test_renders_template_when_file_present(
+        self,
+        patched_server: Any,
+        tmp_plugin_root: Path,
+        sample_project: Path,
+    ) -> None:
+        _write_template(
+            tmp_plugin_root,
+            "episode.md",
+            "# {{title}}\nnumber: {{number}}\nslug: {{slug}}\n",
+        )
+
+        result = patched_server.create_episode(
+            project_slug="test-tutorial",
+            title="New Episode",
+            number=2,
+        )
+
+        assert "created at" in result
+        readme = sample_project / "episodes" / "02-new-episode" / "README.md"
+        content = readme.read_text(encoding="utf-8")
+        assert "# New Episode" in content
+        assert "number: 2" in content
+        assert "slug: 02-new-episode" in content
+        assert "{{title}}" not in content
+
+    def test_returns_actionable_error_when_template_missing(
+        self,
+        patched_server: Any,
+        sample_project: Path,
+    ) -> None:
+        result = patched_server.create_episode(
+            project_slug="test-tutorial",
+            title="Broken Episode",
+            number=9,
+        )
+
+        assert "Template not found" in result
+        assert "episode.md" in result
+        readme = sample_project / "episodes" / "09-broken-episode" / "README.md"
+        assert not readme.exists()
+
+
+class TestCreateSceneTemplate:
+    def test_renders_template_when_file_present(
+        self,
+        patched_server: Any,
+        tmp_plugin_root: Path,
+        sample_episode: Path,
+    ) -> None:
+        _write_template(
+            tmp_plugin_root,
+            "scene.md",
+            "# {{title}}\nnumber: {{number}}\nvisual: {{visual_type}}\n",
+        )
+
+        result = patched_server.create_scene(
+            project_slug="test-tutorial",
+            episode_slug="01-getting-started",
+            title="New Scene",
+            number=3,
+            visual_type="slides",
+        )
+
+        assert "created at" in result
+        scene_file = sample_episode / "scenes" / "03-new-scene.md"
+        content = scene_file.read_text(encoding="utf-8")
+        assert "# New Scene" in content
+        assert "number: 3" in content
+        assert "visual: slides" in content
+        assert "{{title}}" not in content
+
+    def test_returns_actionable_error_when_template_missing(
+        self,
+        patched_server: Any,
+        sample_episode: Path,
+    ) -> None:
+        result = patched_server.create_scene(
+            project_slug="test-tutorial",
+            episode_slug="01-getting-started",
+            title="Broken Scene",
+            number=9,
+        )
+
+        assert "Template not found" in result
+        assert "scene.md" in result
+        scene_file = sample_episode / "scenes" / "09-broken-scene.md"
+        assert not scene_file.exists()


### PR DESCRIPTION
## Summary

- Removes three unreachable `_default_*_template()` fallbacks in `server.py` (~119 lines of dead code). Templates under `templates/` always ship with the plugin, so the fallbacks never executed.
- Replaces the silent fallback with an actionable error: `"Template not found: {path}. Plugin installation may be corrupt."` — a missing template now surfaces immediately instead of hiding behind a divergent inline copy.
- Moves the template existence check ahead of the `mkdir` calls in all three `create_*` tools, so a missing template no longer leaves orphaned empty directories on disk.
- Adds 6 regression tests covering both the present-template and missing-template paths for `create_project_structure`, `create_episode`, and `create_scene`.

Closes #3.

## Test plan

- [x] `python -m pytest tests/` — 157/157 passing (151 existing + 6 new)
- [x] `python -m ruff check servers/vidcraft-server/server.py tests/test_create_structures.py` — clean
- [x] Verify no remaining references to `_default_project_template`, `_default_episode_template`, `_default_scene_template` anywhere in the repo
- [x] Manually verify: create a new project with `templates/project.md` present (happy path)
- [x] Manually verify: temporarily rename `templates/project.md`, confirm actionable error + no orphaned directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)