### PR TITLE
refactor: consolidate duplicated avatar selection criteria (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Model Strategy reference in video-type-creator skill (#4)
 
 ### Changed
-- Nothing yet
+- consolidate avatar selection criteria — `heygen-engineer` references `avatar-selector` as single source of truth; full table (5 categories, age range) lives only in `avatar-selector` (#6)
 
 ### Deprecated
 - Nothing yet

--- a/skills/heygen-engineer/SKILL.md
+++ b/skills/heygen-engineer/SKILL.md
@@ -58,14 +58,21 @@ Each scene in HeyGen needs:
 - **Voice** selection
 - **Speed** (0.8x - 1.2x)
 
-## Avatar Selection Guide
+## Avatar Selection
 
-| Audience | Recommended Style |
-|----------|-------------------|
-| Enterprise B2B | Professional, suit, neutral background |
-| Developer/Tech | Casual, hoodie/polo, modern office |
-| Consumer B2C | Friendly, approachable, bright background |
-| Education | Patient, clear speaking, clean background |
+For avatar recommendations based on audience, use `/vidcraft:avatar-selector` first.
+
+Quick reference (full criteria in `avatar-selector`):
+
+| Audience | Style |
+|----------|-------|
+| Enterprise B2B | Professional, suit, neutral |
+| Developer/Tech | Casual, modern office |
+| Consumer B2C | Friendly, bright |
+| Education | Patient, clean |
+| Internal | Warm, branded |
+
+After avatar is selected, document in episode README.
 
 ## Character Limit Optimization
 


### PR DESCRIPTION
## Summary

- Removes the duplicated audience-style table from `heygen-engineer` (was 4 rows, drifted from `avatar-selector`'s 5 rows — missing `Internal/Onboarding`).
- Replaces it with a slimmed quick-reference (5 rows, no age range) plus an explicit pointer to `/vidcraft:avatar-selector` as the canonical source.
- Full table with age range and all categories lives only in `avatar-selector` from now on.

## Why

Two parallel tables were a maintenance trap: any update had to touch both files and they had already diverged. Single source of truth eliminates that.

## Acceptance criteria (from #6)

- [x] `heygen-engineer` no longer carries a full duplicated avatar table
- [x] `heygen-engineer` explicitly references `/vidcraft:avatar-selector`
- [x] `avatar-selector` holds the canonical, full table (5 categories + age range) — unchanged
- [x] CLAUDE.md routing unchanged — no behavioral change for users

## Test plan

- [x] Open `skills/heygen-engineer/SKILL.md` and confirm the new "Avatar Selection" section
- [x] Open `skills/avatar-selector/SKILL.md` and confirm it is unchanged
- [x] `grep -n avatar-selector skills/heygen-engineer/SKILL.md` returns the cross-reference
- [x] CLAUDE.md routing for "Avatar auswählen" / "Select avatar" still points to `avatar-selector`

Closes #6