### PR TITLE
refactor: consolidate status-to-next-skill matrix (#7)

### DIFF
--- a/knowledge/status-workflow.md
+++ b/knowledge/status-workflow.md
@@ -1,0 +1,64 @@
+# Status → Next Step Mapping
+
+Single source of truth for status-based skill recommendations.
+Consumed by `skills/resume/SKILL.md` (Project-level) and `skills/next-step/SKILL.md` (Episode-level + priority routing).
+
+When adding or renaming a status, update **only this file** — both skills read from here.
+
+## Project Status
+
+Used by `resume` to recommend the next action for a whole project (coarse-grained view).
+
+| Status | Next Skill | Notes |
+|--------|------------|-------|
+| Concept | `/vidcraft:project-conceptualizer` | Develop narrative and episode plan |
+| Brief Complete | `/vidcraft:researcher` | Optional — only if research is needed for this project |
+| Brief Complete | `/vidcraft:script-writer` | If research is done or not needed, jump straight to scripting |
+| Research Done | `/vidcraft:script-writer` | — |
+| Script Draft | `/vidcraft:script-reviewer` | — |
+| Script Approved | `/vidcraft:storyboard-creator` | — |
+| Storyboard Done | `/vidcraft:screenshot-planner` | Followed by `asset-collector`, then `shot-list-creator` |
+| Assets Ready | `/vidcraft:pre-generation-check` | Gate — must PASS before generation |
+| Generated | `/vidcraft:video-reviewer` | — |
+| Reviewed | `/vidcraft:release-director` | — |
+| Published | — | Series complete |
+
+## Episode Status
+
+Used by `next-step` to recommend the most impactful action across all episodes (fine-grained view, priority routing).
+
+| Status | Next Skill | Notes |
+|--------|------------|-------|
+| Not Started | `/vidcraft:script-writer [episode]` | — |
+| Script Draft | `/vidcraft:script-reviewer [episode]` | Highest priority — unblocks downstream work |
+| Script Reviewed | `/vidcraft:storyboard-creator [episode]` | — |
+| Storyboard | `/vidcraft:screenshot-planner [episode]` | Then `asset-collector`, `shot-list-creator` |
+| Assets Collected | `/vidcraft:pre-generation-check [episode]` | Gate — blocks generation if FAIL |
+| Ready for Generation | `/vidcraft:heygen-engineer [episode]` or `/vidcraft:synthesia-engineer [episode]` | Platform formatting, then manual generation in HeyGen/Synthesia |
+| Generated | `/vidcraft:video-reviewer [episode]` | — |
+| QA Passed | `/vidcraft:release-director [project]` | Episode-level done — release is project-level |
+| Final | — | Episode complete |
+
+## Priority Order (for `next-step`)
+
+When multiple episodes are in different statuses, recommend in this order:
+
+1. **No projects exist** → `/vidcraft:new-project`
+2. **Project is Concept, no brief** → `/vidcraft:project-conceptualizer`
+3. **Any episode in Script Draft** → review it first (unblocks pipeline)
+4. **Any episode Not Started** → start the next script
+5. **All scripts approved, no storyboard** → `/vidcraft:storyboard-creator`
+6. **Storyboard done, assets missing** → `/vidcraft:asset-collector`
+7. **Assets collected** → `/vidcraft:pre-generation-check`
+8. **Pre-gen passed** → manual generation step (HeyGen/Synthesia)
+9. **Generated, not reviewed** → `/vidcraft:video-reviewer`
+10. **All episodes Final** → `/vidcraft:release-director`
+
+## Rationale for Two Tables
+
+The two skills operate at different granularities:
+
+- **`resume`** answers *"where is this whole project?"* — uses **Project Status** (coarse).
+- **`next-step`** answers *"what should I literally do in the next 30 minutes?"* — uses **Episode Status** + priority routing (fine).
+
+A single flat table would either lose project-level summary semantics or over-promise episode-level precision. Keeping both, in one file, with shared terminology, is the compromise.

--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -20,21 +20,12 @@ You are the VidCraft workflow router. Analyze the current project state and reco
 
 1. Load session → get active project
 2. Load project data → analyze status of all episodes
-3. Apply routing rules (below)
-4. Return ONE specific recommendation with the skill command
+3. Read `knowledge/status-workflow.md` — the single source of truth for status mappings and priority routing
+4. Apply the **Priority Order** section to pick the most impactful action
+5. Resolve the chosen status against the **Episode Status** table to get the exact skill command
+6. Return ONE specific recommendation
 
-## Routing Rules (Priority Order)
-
-1. **No projects exist** → `/vidcraft:new-project`
-2. **Project is Concept, no brief** → `/vidcraft:project-conceptualizer`
-3. **Episodes exist with Script Draft** → `/vidcraft:script-reviewer [episode]`
-4. **Episodes exist with Not Started** → `/vidcraft:script-writer [episode]`
-5. **All scripts approved, no storyboard** → `/vidcraft:storyboard-creator [episode]`
-6. **Storyboard done, assets missing** → `/vidcraft:asset-collector [episode]`
-7. **Assets ready** → `/vidcraft:pre-generation-check [episode]`
-8. **Pre-gen passed** → "Generate in HeyGen/Synthesia" (manual step)
-9. **Generated, not reviewed** → `/vidcraft:video-reviewer [episode]`
-10. **All episodes Final** → `/vidcraft:release-director [project]`
+Do not maintain a duplicate routing table here — `knowledge/status-workflow.md` owns it. If a routing rule needs to change, edit that file.
 
 ## Output Format
 

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -27,16 +27,9 @@ You are the VidCraft project resumption specialist.
 
 ## Status-Based Recommendations
 
-| Project Status | Recommendation |
-|---------------|----------------|
-| Concept | Run `/vidcraft:project-conceptualizer` |
-| Brief Complete | Run `/vidcraft:script-writer` for first episode |
-| Script Draft | Run `/vidcraft:script-reviewer` |
-| Script Approved | Run `/vidcraft:storyboard-creator` |
-| Storyboard Done | Run `/vidcraft:screenshot-planner` |
-| Assets Ready | Run `/vidcraft:pre-generation-check` |
-| Generated | Run `/vidcraft:video-reviewer` |
-| Reviewed | Run `/vidcraft:release-director` |
+Read `knowledge/status-workflow.md` and apply the **Project Status** table to map the project's current status to the next skill. That file is the single source of truth — do not maintain a duplicate table here.
+
+When the same status has multiple rows (e.g. `Brief Complete`), use the Notes column to pick the right one for this project.
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

- Single source of truth: `knowledge/status-workflow.md` mit zwei Tabellen (Project + Episode), Notes-Spalte und Priority Order
- `skills/resume/SKILL.md` und `skills/next-step/SKILL.md` referenzieren die Knowledge-Datei statt eigene Tabellen zu pflegen
- Drift aufgelöst: `Storyboard Done` → `screenshot-planner` (kanonisch); `asset-collector` als Follow-up in Notes
- `Brief Complete`: zwei Zeilen für die "research first?"-Entscheidung statt 1:1-Mapping

Closes #7

## Acceptance Criteria

- [x] Eine einzige Status→Skill-Matrix
- [x] `resume` und `next-step` zeigen identische Empfehlungen für gleiche Status (beide lesen aus derselben Datei)
- [x] Neue Status nur an einer Stelle pflegen
- [x] Bestehende Workflows unverändert

## Test plan

- [x] `/vidcraft:resume <project>` mit Status `Storyboard Done` → empfiehlt `/vidcraft:screenshot-planner`
- [x] `/vidcraft:next-step` mit Episode-Status `Script Draft` → empfiehlt `/vidcraft:script-reviewer`
- [x] Beide Skills bei gleichem Projekt-/Episode-Stand → konsistente Empfehlung
- [ ] Knowledge-Datei manuell editieren (z.B. Notes ändern) → beide Skills nutzen die Änderung beim nächsten Aufruf