### PR TITLE
refactor: extract script-writing rules and platform constraints to knowledge/ (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - inline Model Strategy guideline table in CLAUDE.md (#4)
 - Model Strategy reference in video-type-creator skill (#4)
+- `knowledge/script-writing-rules.md` — narration rules, pause syntax, on-screen text rules, post-production overlay markers (#8)
+- `knowledge/platform-checklist.md` — HeyGen and Synthesia constraints (backgrounds, character limits, pause support, layouts) (#8)
 
 ### Changed
 - consolidate avatar selection criteria — `heygen-engineer` references `avatar-selector` as single source of truth; full table (5 categories, age range) lives only in `avatar-selector` (#6)
+- `script-writer`, `heygen-engineer`, `synthesia-engineer`, `storyboard-creator` reference `knowledge/script-writing-rules.md` and `knowledge/platform-checklist.md` instead of duplicating narration rules and platform constraints (#8)
 
 ### Deprecated
 - Nothing yet

--- a/knowledge/platform-checklist.md
+++ b/knowledge/platform-checklist.md
@@ -1,0 +1,127 @@
+# Platform Checklist — HeyGen and Synthesia Constraints
+
+Single source of truth for platform-specific limits and quirks. Skills
+like `script-writer`, `heygen-engineer`, `synthesia-engineer`, and
+`storyboard-creator` reference this file instead of duplicating the
+rules.
+
+For narration and on-screen-text rules that are platform-independent,
+see [`script-writing-rules.md`](script-writing-rules.md).
+
+## HeyGen
+
+### Hard Constraints
+
+| Constraint | Detail |
+|------------|--------|
+| One background per scene | One image, video, or color per HeyGen scene. Multiple backgrounds = split into multiple scenes. |
+| No timed text overlays | Overlays are visible for the entire scene duration. Timed overlays must be done in post-production. |
+| Max ~1500 characters per scene | Hard limit; split at natural pauses if exceeded. |
+| Max scenes per video | Plan-dependent. Check current HeyGen plan. |
+| One avatar per scene | No multi-avatar scenes. |
+
+### Pause Support
+
+HeyGen supports manual pauses inside narration:
+
+| Marker | HeyGen behavior |
+|--------|-----------------|
+| `[pause 0.5s]` | 0.5 second pause |
+| `[pause 1s]` | 1 second pause |
+| Paragraph break | ~0.5 second pause (default) |
+
+The same syntax is used in the source scripts (see
+[`script-writing-rules.md`](script-writing-rules.md#pause-syntax)).
+
+### Splitting Scenes for HeyGen
+
+Split a content scene when:
+
+- It exceeds 1500 characters
+- It needs more than one background
+- It needs to switch avatar
+
+When splitting:
+
+1. Cut at a natural pause point in the narration
+2. Add a transition between the split scenes (cut or fade, defined
+   in the storyboard)
+3. Keep visual continuity (same brand frame, same lower-third)
+
+### What Belongs in Post-Production
+
+These cannot be done in HeyGen and must be planned for Shotcut /
+Kdenlive / Premiere:
+
+- Timed text overlays (overlays that appear at specific timestamps)
+- Multi-track music with ducking
+- Cross-scene transitions beyond cut/fade
+- Picture-in-picture beyond HeyGen's avatar overlay
+- Any animation that needs frame-precise timing
+
+Mark these in scene scripts using the `[post-production ...]` syntax
+(see [`script-writing-rules.md`](script-writing-rules.md#timed-overlays-post-production-marker)).
+
+### HeyGen Scene Format
+
+Each scene needs:
+
+- **Script text** (narration)
+- **Avatar** selection (see `/vidcraft:avatar-selector`)
+- **Background** — exactly one per scene
+- **Avatar position** — left, center, or right
+- **Voice** selection
+- **Speed** — 0.8x to 1.2x
+
+## Synthesia
+
+### Hard Constraints
+
+| Constraint | Detail |
+|------------|--------|
+| Max ~1000 characters per slide | Slide-based; split at sentence boundary if exceeded. |
+| Max slides per video | 50+ (plan-dependent). |
+| Languages | 130+ supported. |
+| Slide-based scene structure | 1 scene typically maps to 1 slide. |
+
+### Slide Format
+
+Each Synthesia slide needs:
+
+- **Script** — narration text, max ~1000 characters
+- **Avatar** selection (or "no avatar" for text-only slides)
+- **Layout** — avatar left/right/center, with or without background media
+- **Background** — solid color, image, video, or screen recording
+- **Text overlays** — headlines, bullet points, key terms
+- **Media** — images, screen recordings, animations
+
+### Splitting Slides for Synthesia
+
+Split a slide when it exceeds 1000 characters:
+
+1. Cut at a natural sentence break
+2. Use a transition slide for continuity
+3. Keep related content on adjacent slides
+
+### Layout Templates
+
+| Scene Type | Recommended Layout |
+|------------|--------------------|
+| Intro / Outro | Avatar center, branded background |
+| Explanation | Avatar left, key points right |
+| Screencast | Screen recording full, avatar overlay corner |
+| Comparison | Split screen, before/after |
+| Summary | Text-only with bullet points |
+| CTA | Avatar center, CTA text overlay |
+
+## Cross-Platform Notes
+
+These behaviors are the same in both platforms and worth knowing:
+
+- Screen recordings should be captured separately (OBS, screen capture)
+  and uploaded as background media — both platforms struggle with
+  in-platform screen recording quality.
+- Brand assets (logo, lower-third, color palette) are uploaded once and
+  reused across scenes — define them in the project README.
+- Voice cloning (paid feature on both platforms) requires a separate
+  upload and approval flow — not covered by these skills.

--- a/knowledge/script-writing-rules.md
+++ b/knowledge/script-writing-rules.md
@@ -1,0 +1,79 @@
+# Script Writing Rules — Single Source of Truth
+
+These rules apply to all narration written for AI-generated videos
+(HeyGen, Synthesia, or any other avatar platform). Skills like
+`script-writer`, `script-reviewer`, `storyboard-creator`, and
+`heygen-engineer` reference this file instead of duplicating the rules.
+
+For platform-specific constraints (character limits, background rules,
+overlay timing) see [`platform-checklist.md`](platform-checklist.md).
+
+## Narration Rules
+
+| Rule | Why |
+|------|-----|
+| Max 20 words per sentence | Avatars sound unnatural in long sentences |
+| Use active voice ("Click the button") | Direct, viewer-focused |
+| Address the viewer with "you" | Builds connection |
+| Avoid filler words: "basically", "actually", "just", "really" | Cuts run-time without losing meaning |
+| Write for spoken delivery, not for reading | Punctuation = breath, not grammar |
+
+### Pause Syntax
+
+Both HeyGen and the storyboard format use the same pause markers in
+narration text. Keep them in the script source so all downstream tools
+(`heygen-engineer`, `storyboard-creator`) can interpret them.
+
+| Marker | Meaning |
+|--------|---------|
+| `[pause 0.5s]` | Short breath between paragraphs |
+| `[pause 1s]` | Standard pause between topics |
+| Paragraph break (blank line) | Implicit ~0.5s pause |
+
+`[pause]` without a duration is allowed for legacy scripts and is
+interpreted as 2 seconds. Prefer the explicit form in new scripts.
+
+## On-Screen Text Rules
+
+| Rule | Why |
+|------|-----|
+| Max 7 words per overlay | Readable in 2-3 seconds |
+| Use for: key terms, commands, URLs, step numbers | High signal density |
+| Never duplicate the narration verbatim | Wastes the visual channel |
+| Use for emphasis, not redundancy | If both channels say the same thing, drop one |
+
+### Timed Overlays (Post-Production Marker)
+
+HeyGen does not support overlays that appear/disappear at specific
+timestamps within a scene — overlays are visible for the entire scene
+duration (see [`platform-checklist.md`](platform-checklist.md#heygen)).
+
+If you need timed overlays, mark them in the scene script for
+post-production tools (Shotcut, Kdenlive):
+
+```
+[post-production overlay: "Save the file" at 00:12-00:15]
+```
+
+The `heygen-engineer` strips these markers before sending the script
+to HeyGen and surfaces them in the post-production task list.
+
+## Visual Direction Basics
+
+These apply to every scene file, regardless of visual type. The
+`storyboard-creator` enriches them with platform-specific details.
+
+- Be specific: "Show terminal with cursor on line 5", not "Show terminal"
+- Name transitions: "Fade from avatar to screencast"
+- Mention avatar gestures when intentional: "Avatar points right to
+  highlight the sidebar"
+- Specify highlights: "Red box around the Submit button", not
+  "highlight the button"
+
+## Anti-Patterns
+
+- AI-sounding language ("In this comprehensive guide", "Let's delve
+  into") — see [`ai-language-patterns.md`](ai-language-patterns.md)
+- Wall of text narration without visual changes
+- Missing CTA at the end of the episode
+- Inconsistent tone across scenes (set tone in project README, hold to it)

--- a/skills/heygen-engineer/SKILL.md
+++ b/skills/heygen-engineer/SKILL.md
@@ -23,10 +23,8 @@ You are a HeyGen platform specialist. You optimize video content for HeyGen's ge
 ## Workflow
 
 1. **Load episode data** — all scenes, narration, visual direction
-2. **Check platform limits:**
-   - Max characters per scene: ~1500
-   - Max scenes per video: varies by plan
-   - Supported languages and voices
+2. **Check platform limits** — see `knowledge/platform-checklist.md` (HeyGen section)
+   for the authoritative list (one background per scene, ~1500 chars, pause syntax)
 3. **Select avatar** based on project brand, audience, language
 4. **Format script** for HeyGen's scene structure
 5. **Generate clipboard output** for easy copy-paste into HeyGen
@@ -34,29 +32,20 @@ You are a HeyGen platform specialist. You optimize video content for HeyGen's ge
 
 ## HeyGen Platform Limitations
 
-These constraints are confirmed from real production experience:
+All HeyGen constraints (one background per scene, no timed overlays,
+character limit, pause syntax) and the HeyGen scene format are defined
+in `knowledge/platform-checklist.md` (HeyGen section). Read it before
+formatting a script.
 
-### One Background Per Scene
-HeyGen allows only ONE background (image, video, or color) per scene. If a content scene requires multiple backgrounds (e.g., two different slides), split it into multiple HeyGen scenes while keeping the narration flow natural.
+Pause and overlay syntax is shared with the source script format —
+see `knowledge/script-writing-rules.md`.
 
-### No Timed Text Overlays
-Text overlays in HeyGen are displayed for the ENTIRE scene duration. There is no way to show/hide text at specific timestamps. Plan timed text overlays as **post-production tasks** (Shotcut/Kdenlive) instead.
+Key constraints to enforce here:
 
-### Pause Support
-HeyGen supports manual pauses between paragraphs. Use:
-- `[pause 1s]` — standard pause between topics (maps to 1 second in HeyGen)
-- `[pause 0.5s]` — short breath between paragraphs
-- Paragraph breaks in narration = 0.5s pause by default
-
-## HeyGen Scene Format
-
-Each scene in HeyGen needs:
-- **Script text** (narration)
-- **Avatar** selection
-- **Background** (color, image, or video) — exactly ONE per scene
-- **Avatar position** (left, center, right)
-- **Voice** selection
-- **Speed** (0.8x - 1.2x)
+- One background per HeyGen scene → split if more needed
+- Overlays are full-scene-duration only → timed overlays go to post-production
+- ~1500 characters per scene (hard limit)
+- Pauses: `[pause 0.5s]`, `[pause 1s]`
 
 ## Avatar Selection
 

--- a/skills/script-writer/SKILL.md
+++ b/skills/script-writer/SKILL.md
@@ -54,36 +54,30 @@ You are a professional video script writer for AI-generated videos (HeyGen/Synth
 
 ## Script Writing Rules
 
-### Narration
-- Write for spoken delivery, not reading
-- Short sentences (max 20 words)
-- Use active voice: "Click the button" not "The button should be clicked"
-- Use "you" to address the viewer directly
-- Avoid filler words: "basically", "actually", "just"
-- Pause indicators: Use `[pause]` for 2-second breaks
+Narration, on-screen text, pause syntax and visual direction basics are
+defined in `knowledge/script-writing-rules.md` — single source of truth
+across all script-writing skills.
 
-### On-Screen Text
-- Max 7 words per text overlay
-- Use for: key terms, commands, URLs, step numbers
-- Never duplicate the narration word-for-word
-- Use for emphasis, not redundancy
-- **HeyGen limitation:** Text overlays show for the ENTIRE scene duration.
-  If text needs to appear/disappear at specific timestamps, mark it as
-  `[post-production overlay: "text" at MM:SS-MM:SS]` for Shotcut/Kdenlive
+Quick reminders:
 
-### Visual Direction
-- Be specific: "Show terminal with cursor on line 5" not "Show terminal"
-- Include transitions: "Fade from avatar to screencast"
-- Mention avatar gestures: "Avatar points right to highlight sidebar"
-- Specify highlighting: "Red box around the Submit button"
+- Narration: max 20 words/sentence, active voice, address the viewer with "you"
+- On-screen text: max 7 words per overlay, never duplicate narration
+- Pauses: `[pause 0.5s]`, `[pause 1s]`
+- Timed overlays: mark as `[post-production overlay: "text" at MM:SS-MM:SS]`
 
-### Platform Awareness
-- **HeyGen:** Supports gestures, custom backgrounds, screen sharing.
-  Limitations: one background per scene, text overlays not timed (full scene only), pauses supported (`[pause 0.5s]`, `[pause 1s]`)
-- **Synthesia:** Supports slides, screen recording overlay, text animations
+## Platform Awareness
+
+Platform-specific limits (HeyGen/Synthesia character limits, background
+rules, overlay timing) are in `knowledge/platform-checklist.md`.
+
+Quick reminders:
+
+- **HeyGen:** one background per scene, no timed overlays, ~1500 chars per scene
+- **Synthesia:** slide-based, ~1000 chars per slide, 130+ languages
 
 ## Anti-Patterns to Avoid
-- AI-sounding language: "In this comprehensive guide" → "Let me show you"
+
+- AI-sounding language: see `knowledge/ai-language-patterns.md`
 - Over-explaining: Get to the point quickly
 - Wall of text narration without visual changes
 - Missing CTA at the end

--- a/skills/storyboard-creator/SKILL.md
+++ b/skills/storyboard-creator/SKILL.md
@@ -71,21 +71,18 @@ You are a professional video storyboard artist for AI-generated videos. You tran
 
 ## Platform-Specific Notes
 
-### HeyGen
-- Supports custom backgrounds — but only ONE per scene
-- If a content scene needs multiple backgrounds, mark it for splitting:
-  `[HeyGen split: 2 scenes]` — the `heygen-engineer` will handle the actual split
-- Avatar gestures configurable
-- Screen share overlay possible
-- Background music layers
-- Text overlays: full scene duration only (no timed show/hide)
-- Pauses: supported between paragraphs (`[pause 0.5s]`, `[pause 1s]`)
+Platform constraints (HeyGen and Synthesia) are defined in
+`knowledge/platform-checklist.md`. Pause and overlay syntax is shared
+with the source script format — see `knowledge/script-writing-rules.md`.
 
-### Synthesia
-- Slide-based scene structure
-- Screen recording overlays
-- Text animation templates
-- Split-screen layouts
+Storyboard-specific reminders:
+
+- **HeyGen:** if a scene needs multiple backgrounds, mark it for the
+  `heygen-engineer` to split with `[HeyGen split: N scenes]`
+- **HeyGen:** overlays are full-scene-duration only — for timed overlays
+  use `[post-production overlay: ...]`
+- **Synthesia:** typically one slide per scene; pick layout from the
+  layout template table in the platform checklist
 
 ## Output
 

--- a/skills/synthesia-engineer/SKILL.md
+++ b/skills/synthesia-engineer/SKILL.md
@@ -23,43 +23,28 @@ You are a Synthesia platform specialist. You optimize video content for Synthesi
 ## Workflow
 
 1. **Load episode data** — all scenes, narration, visual direction
-2. **Check platform limits:**
-   - Max characters per slide: ~1000
-   - Max slides per video: 50+
-   - Supported languages: 130+
+2. **Check platform limits** — see `knowledge/platform-checklist.md` (Synthesia section)
+   for the authoritative list (~1000 chars/slide, 50+ slides, 130+ languages)
 3. **Map scenes to slides** (1 scene = 1 slide typically)
 4. **Select avatar** based on project brand and audience
 5. **Configure slide layouts** per scene type
 6. **Format script** for Synthesia's editor
 7. **Generate clipboard output** for copy-paste
 
-## Synthesia Slide Structure
+## Synthesia Slide Structure, Layouts, Character Limits
 
-Each slide needs:
-- **Script** (narration text, max ~1000 chars)
-- **Avatar** selection (or "no avatar" for text-only slides)
-- **Layout** (avatar left/right/center, with/without background media)
-- **Background** (solid color, image, video, screen recording)
-- **Text overlays** (headlines, bullet points, key terms)
-- **Media** (images, screen recordings, animations)
+The Synthesia slide format, layout templates, and character-limit
+splitting rules are defined in `knowledge/platform-checklist.md`
+(Synthesia section). Read it before formatting a script.
 
-## Layout Templates
+Narration rules (max 20 words/sentence, active voice, pauses) are
+shared across platforms — see `knowledge/script-writing-rules.md`.
 
-| Scene Type | Recommended Layout |
-|------------|-------------------|
-| Intro/Outro | Avatar center, branded background |
-| Explanation | Avatar left, key points right |
-| Screencast | Screen recording full, avatar overlay corner |
-| Comparison | Split screen, before/after |
-| Summary | Text-only with bullet points |
-| CTA | Avatar center, CTA text overlay |
+Key constraints to enforce here:
 
-## Character Limit Optimization
-
-If a slide exceeds 1000 characters:
-1. Split at a natural sentence break
-2. Use transition slides for continuity
-3. Keep related content on adjacent slides
+- ~1000 characters per slide (hard limit) → split at sentence break
+- 1 scene typically maps to 1 slide
+- Choose layout per scene type (intro, explanation, screencast, etc.)
 
 ## Output
 

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -142,6 +142,51 @@ class TestToolModules:
         assert (PLUGIN_ROOT / "tools" / "analysis" / "document_parser.py").exists()
 
 
+class TestKnowledgeFiles:
+    """Validate knowledge/ Single-Source-of-Truth files and skill references.
+
+    Issue #8: knowledge/ holds reusable plugin knowledge so duplicated
+    constraints in skills can be replaced with references.
+    """
+
+    def test_script_writing_rules_exists(self) -> None:
+        path = PLUGIN_ROOT / "knowledge" / "script-writing-rules.md"
+        assert path.exists(), "knowledge/script-writing-rules.md must exist"
+
+    def test_platform_checklist_exists(self) -> None:
+        path = PLUGIN_ROOT / "knowledge" / "platform-checklist.md"
+        assert path.exists(), "knowledge/platform-checklist.md must exist"
+
+    @pytest.mark.parametrize(
+        "skill_name",
+        ["script-writer", "heygen-engineer", "storyboard-creator"],
+    )
+    def test_skill_references_script_writing_rules(self, skill_name: str) -> None:
+        skill_path = PLUGIN_ROOT / "skills" / skill_name / "SKILL.md"
+        text = skill_path.read_text(encoding="utf-8")
+        assert "knowledge/script-writing-rules.md" in text, (
+            f"{skill_name} must reference knowledge/script-writing-rules.md "
+            f"instead of duplicating narration/pause/text-overlay rules."
+        )
+
+    @pytest.mark.parametrize(
+        "skill_name",
+        [
+            "script-writer",
+            "heygen-engineer",
+            "synthesia-engineer",
+            "storyboard-creator",
+        ],
+    )
+    def test_skill_references_platform_checklist(self, skill_name: str) -> None:
+        skill_path = PLUGIN_ROOT / "skills" / skill_name / "SKILL.md"
+        text = skill_path.read_text(encoding="utf-8")
+        assert "knowledge/platform-checklist.md" in text, (
+            f"{skill_name} must reference knowledge/platform-checklist.md "
+            f"instead of duplicating HeyGen/Synthesia constraints."
+        )
+
+
 class TestPluginVersion:
     """Single source of truth: plugin.json version must match get_plugin_version()."""
 


### PR DESCRIPTION
## Summary

Adds the two nice-to-have knowledge files from #8 and removes duplicated content from four skills.

## What changed

- `knowledge/script-writing-rules.md` — narration rules, pause syntax, on-screen text rules, post-production overlay markers
- `knowledge/platform-checklist.md` — HeyGen and Synthesia constraints (backgrounds, character limits, pauses, layouts)
- `script-writer`, `heygen-engineer`, `synthesia-engineer`, `storyboard-creator` now reference these files instead of duplicating
- New test class `TestKnowledgeFiles` enforces both files exist AND that the four skills reference them — catches future drift at CI time

## Why

The mandatory items from #8 (`knowledge/` dir, `ai-language-patterns.md`, `status-workflow.md`) shipped via #5 and #7. This PR closes the loop by tackling the two nice-to-haves listed in #8.

Pause syntax (`[pause 0.5s]`, `[pause 1s]`), the "one background per HeyGen scene" rule, and "no timed overlays" were each in 2-3 skill files. Next time someone changes them they would only update one place — the others would silently rot.

## Test plan

- [x] `pytest tests/` — 166 passed (was 157, +9 for new TestKnowledgeFiles class)
- [x] `ruff check tools/ tests/ servers/` — clean
- [x] `ruff format --check tools/ tests/ servers/` — clean
- [x] Manual sanity check: open one of the four updated skills in Claude and confirm the references resolve correctly

Closes #8.
