### PR TITLE
refactor(skills): migrate opus 4.6 to 4.7 — phase 1 (frontmatter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nothing yet
 
 ### Changed
-- Nothing yet
+- migrate 10 opus skills from `claude-opus-4-6` to `claude-opus-4-7` (#24, phase 1)
+- update test whitelist `valid_models` to accept `claude-opus-4-7`, drop `claude-opus-4-6`
 
 ### Deprecated
 - Nothing yet
@@ -24,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - Nothing yet
+
+### Notes
+- Frontmatter-only migration. Body-hardening for 4.7 default-shifts (verbosity,
+  tool-use, multi-turn) follows in a separate PR — see #24 phase 2.
 
 ## [1.2.0] - 2026-04-25
 

--- a/skills/audience-researcher/SKILL.md
+++ b/skills/audience-researcher/SKILL.md
@@ -2,7 +2,7 @@
 name: audience-researcher
 description: "Deep-dive audience analysis: personas, pain points, knowledge levels, and content preferences. Use before brief creation to ground the project in real audience needs."
 argument-hint: "<project-slug-or-topic>"
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 allowed-tools:
   - Read

--- a/skills/brief-creator/SKILL.md
+++ b/skills/brief-creator/SKILL.md
@@ -2,7 +2,7 @@
 name: brief-creator
 description: "Create a creative brief from project requirements, document analysis, or user input. The brief defines goals, audience, tone, and constraints before script writing begins."
 argument-hint: "<project-slug>"
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 allowed-tools:
   - Read

--- a/skills/doc-analyzer/SKILL.md
+++ b/skills/doc-analyzer/SKILL.md
@@ -2,7 +2,7 @@
 name: doc-analyzer
 description: "Analyze existing documentation (PDF, DOCX, Markdown) and extract structured content for video production. Suggests video structure, key points, and scene breakdown."
 argument-hint: "<file-path> [video-type]"
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 allowed-tools:
   - Read

--- a/skills/project-conceptualizer/SKILL.md
+++ b/skills/project-conceptualizer/SKILL.md
@@ -2,7 +2,7 @@
 name: project-conceptualizer
 description: "Multi-phase concept development for video projects. Defines narrative arc, episode structure, visual identity, and production approach through guided discovery."
 argument-hint: "<project-slug>"
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 allowed-tools:
   - Read

--- a/skills/promo-writer/SKILL.md
+++ b/skills/promo-writer/SKILL.md
@@ -2,7 +2,7 @@
 name: promo-writer
 description: "Write platform-specific promotional text for video releases: YouTube descriptions, social media posts, email copy, and blog excerpts."
 argument-hint: "<project-slug> [platform]"
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 allowed-tools:
   - Read

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -2,7 +2,7 @@
 name: researcher
 description: "Research topics for video content: competitor videos, best practices, source material, and technical accuracy. Use when a project needs factual grounding."
 argument-hint: "<topic-or-project-slug>"
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 allowed-tools:
   - Read

--- a/skills/script-writer/SKILL.md
+++ b/skills/script-writer/SKILL.md
@@ -2,7 +2,7 @@
 name: script-writer
 description: "Write video scripts with narration, on-screen text, and visual cues optimized for the video type. Use when writing new scripts or revising existing ones."
 argument-hint: "<project-slug> <episode-slug>"
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 allowed-tools:
   - Read

--- a/skills/storyboard-creator/SKILL.md
+++ b/skills/storyboard-creator/SKILL.md
@@ -2,7 +2,7 @@
 name: storyboard-creator
 description: "Create scene-by-scene storyboards with visual directions, transitions, and screenshot positions. Use after script is approved."
 argument-hint: "<project-slug> <episode-slug>"
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 allowed-tools:
   - Read

--- a/skills/video-reviewer/SKILL.md
+++ b/skills/video-reviewer/SKILL.md
@@ -2,7 +2,7 @@
 name: video-reviewer
 description: "Comprehensive post-generation review of a video episode. Checks pacing, visual consistency, narration quality, brand compliance, and accessibility."
 argument-hint: "<project-slug> <episode-slug>"
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 allowed-tools:
   - Read

--- a/skills/video-type-creator/SKILL.md
+++ b/skills/video-type-creator/SKILL.md
@@ -2,7 +2,7 @@
 name: video-type-creator
 description: "Create new video type documentation files for the vidcraft type library. Use when adding a new video type like 'webinar', 'case-study', etc."
 argument-hint: "<video-type-name>"
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 allowed-tools:
   - Read

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -63,7 +63,7 @@ class TestSkillStructure:
         end = text.index("---", 3)
         meta = yaml.safe_load(text[3:end])
         valid_models = {
-            "claude-opus-4-6",
+            "claude-opus-4-7",
             "claude-sonnet-4-6",
             "claude-haiku-4-5-20251001",
         }


### PR DESCRIPTION
## Summary

Phase 1 of the 4.6 → 4.7 model migration tracked in #24. Mechanical only:

- 10 opus skills updated: `model: claude-opus-4-6` → `model: claude-opus-4-7`
- `tests/test_plugin_structure.py` `valid_models` set: dropped `claude-opus-4-6`, added `claude-opus-4-7`

## What this PR explicitly does NOT do

This is **not** the body-hardening that the 4.7 migration guide requires. Per #24, frontmatter swap alone is risky because 4.7 shifts five defaults (verbosity, tool-use frequency, subagent dispatch, multi-turn behavior, effort level) that can regress prompts tuned to 4.6.

Body-hardening per skill follows in a **separate PR** — see #24 phase 2. Splitting keeps the mechanical change isolated for safe rollback.

## Affected files

| Skill | Risk profile |
|---|---|
| audience-researcher | Long-form + research-heavy |
| brief-creator | Long-form |
| doc-analyzer | MCP-heavy |
| project-conceptualizer | **Multi-turn discovery** — highest risk |
| promo-writer | Long-form |
| researcher | Long-form + research-heavy |
| script-writer | Long-form |
| storyboard-creator | Structured |
| video-reviewer | Long-form + tool-use |
| video-type-creator | WebSearch-heavy |

## Test plan

- [x] `pytest tests/` — 176/176 green locally
- [x] CI green
- [x] Manual sanity-check: invoke one skill end-to-end on a sample project (recommend `script-writer` against any existing project) before merging
- [x] Verify no skill still pins `claude-opus-4-6` (should be 0): `grep -r "claude-opus-4-6" skills/ tests/`

## Follow-ups (out of scope for this PR)

- Phase 2: body-hardening per pattern A/B/C from #24
- Phase 3: validation runs against fresh sample projects
- Effort-level decision (xhigh global vs. pin to high) — to be documented in `CLAUDE.md` once observed in practice

Closes part of #24 (phase 1 only).