### PR TITLE
refactor(skills): harden 9 opus skills for 4.7 default-shifts — phase 2a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - migrate 10 opus skills from `claude-opus-4-6` to `claude-opus-4-7` (#24, phase 1)
 - update test whitelist `valid_models` to accept `claude-opus-4-7`, drop `claude-opus-4-6`
+- harden 9 opus skills against 4.7 default-shifts (#24, phase 2a):
+  - script-writer: hard floor 80–150 words narration per scene
+  - brief-creator: required depth per section (objective, audience, tone, etc.)
+  - promo-writer: explicit length/hashtag floors per platform
+  - storyboard-creator: no scene field may be left blank or "tbd"
+  - video-reviewer: notes-column depth requirements per PASS/WARN/FAIL
+  - audience-researcher: ≥3 parallel WebSearches + persona depth floor
+  - researcher: ≥3 parallel WebSearches + ≥2 sources per finding + depth floor
+  - doc-analyzer: ordered MCP tool execution (3+4+5 in parallel)
+  - video-type-creator: ≥3 parallel WebSearches with distinct purposes
 
 ### Deprecated
 - Nothing yet
@@ -27,8 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nothing yet
 
 ### Notes
-- Frontmatter-only migration. Body-hardening for 4.7 default-shifts (verbosity,
-  tool-use, multi-turn) follows in a separate PR — see #24 phase 2.
+- Phase 1 was frontmatter-only. Phase 2a addresses verbosity (Pattern A) and
+  tool-use frequency (Pattern B) per the 4.7 migration guide.
+- The multi-turn discovery refactor for `project-conceptualizer` (Pattern C)
+  and the effort-level decision (Pattern D) follow in a separate PR — see
+  #24 phase 2b.
 
 ## [1.2.0] - 2026-04-25
 

--- a/skills/audience-researcher/SKILL.md
+++ b/skills/audience-researcher/SKILL.md
@@ -25,11 +25,15 @@ You are an audience insights specialist who builds detailed viewer profiles for 
    - What product/service/topic is the video about?
    - What's the video's goal? (educate, sell, onboard)
 
-2. **Research audience behavior:**
-   - Search forums (Stack Overflow, Reddit, GitHub Issues) for common questions
-   - Find pain points and frustrations with the topic
-   - Identify knowledge level (beginner/intermediate/advanced)
-   - Note terminology the audience actually uses vs. marketing jargon
+2. **Research audience behavior** — you MUST run **at least 3 WebSearch calls**
+   before writing any persona. Each search has a distinct purpose:
+   - Search 1 — **Forums for common questions** (Stack Overflow, Reddit, GitHub Issues): "site:stackoverflow.com <topic>" or "site:reddit.com <topic>"
+   - Search 2 — **Pain points and frustrations**: "<topic> frustrating" / "<topic> doesn't work" / "<topic> problems"
+   - Search 3 — **Terminology the audience actually uses** vs. marketing jargon: scan forum thread titles and top comments for vernacular
+
+   Run these 3 in **parallel** (independent queries — fan-out is wanted here).
+   If the topic is highly technical or niche, add a 4th WebFetch on the most
+   relevant forum thread to read full context, not just snippets.
 
 3. **Build personas** (1-3 per project):
    - Role/title
@@ -80,3 +84,20 @@ You are an audience insights specialist who builds detailed viewer profiles for 
 - Back up claims with real sources (forum posts, community discussions)
 - Flag when audience segments have conflicting needs
 - Recommend splitting into multiple videos if audience is too diverse
+
+## Required depth (hard floor)
+
+A persona file passes review only if:
+
+- **Each persona** has all 5 fields populated with one concrete sentence each
+  (not "developer" — write "Senior backend dev, 5+ yrs PHP, currently
+  evaluating OXID 7 for a B2B replatform").
+- **Audience Insights** lists **at least 3 common questions WITH source URLs**
+  (not "developers ask about caching"; write the actual question + the link).
+- **Misconception** and **Knowledge gap** are filled with one specific item
+  each, not skipped.
+- **Content Recommendations** include the `because [reason]` clause for every
+  field — the reason must reference one of the WebSearch findings.
+
+Thin personas (one-word fields, no sources, no reasons) fail downstream brief
+and script work — re-research before saving.

--- a/skills/brief-creator/SKILL.md
+++ b/skills/brief-creator/SKILL.md
@@ -53,6 +53,20 @@ A good brief answers ALL of these:
 - [ ] **What** should they do after? (CTA)
 - [ ] **What** can't we do? (Constraints)
 
+### Required depth per section (hard floor)
+
+A production-ready brief is dense, not just complete:
+
+- **Objective:** 2–4 sentences. State the business outcome AND the viewer outcome.
+- **Audience:** at least 3 concrete attributes (role, knowledge level, primary pain). Generic audiences ("developers") fail review.
+- **Key Messages:** 3–5, each with a one-sentence justification (why it matters to the audience).
+- **Tone:** 2–3 adjectives **plus** one negative ("confident — not preachy"). Single adjectives like "professional" fail review.
+- **CTA:** one sentence, action verb first, measurable.
+- **Constraints:** at least duration, platform, language. Add brand/legal if known.
+
+If a section can be written in fewer words than the floor, the brief is not yet
+ready — go back to the user with one batched question, not a multi-turn drip.
+
 ## Anti-Patterns
 
 - Generic audience: "everyone" → Be specific: "PHP developers using OXID 7.x"

--- a/skills/doc-analyzer/SKILL.md
+++ b/skills/doc-analyzer/SKILL.md
@@ -24,25 +24,32 @@ You are a content strategist who transforms existing documentation into video pr
 
 ## Workflow
 
-1. **Analyze the document** using `analyze_document()` MCP tool
+You MUST execute the 5 MCP analysis tools below **in order, before writing
+any output**. Skipping or reordering them produces shallow recommendations
+that miss content density signals.
+
+1. **Analyze the document** using `analyze_document()` MCP tool — REQUIRED FIRST
    - Get full section breakdown with content types
    - Note code blocks, lists, images (each suggests different scene types)
 
-2. **Assess complexity** using `analyze_complexity()`
+2. **Assess complexity** using `analyze_complexity()` — REQUIRED, depends on step 1
    - Get recommended video type and episode count
    - Understand content density and structure
 
-3. **Extract key points** using `extract_key_points()`
+3. **Extract key points** using `extract_key_points()` — REQUIRED
    - Identify the most important content for video coverage
    - Note which points need visual support (code demos, screenshots)
 
-4. **Suggest video structure** using `suggest_video_structure()`
+4. **Suggest video structure** using `suggest_video_structure()` — REQUIRED
    - Get scene-by-scene breakdown with timing estimates
    - Map document sections to video scenes
 
-5. **Suggest additional topics** using `suggest_video_topics()`
+5. **Suggest additional topics** using `suggest_video_topics()` — REQUIRED
    - Identify if the document could spawn multiple videos
    - Recommend types for each potential video
+
+Steps 3, 4, 5 are independent of each other (all depend on steps 1+2) and
+**should be run in parallel** to keep latency low.
 
 6. **Present findings** to the user with:
    - Document summary (format, sections, word count)

--- a/skills/promo-writer/SKILL.md
+++ b/skills/promo-writer/SKILL.md
@@ -123,3 +123,22 @@ Pick exactly ONE category from this list:
 - Always include a clear, single CTA per platform
 - Match the brand tone from project brief
 - ALL embed codes must use `youtube-nocookie.com` — never `youtube.com` (DSGVO)
+
+## Length & Hashtag Floors (hard requirements)
+
+The platform spec above lists target ranges. Treat the **lower bound** as a
+hard floor — a 60-word LinkedIn post or a 5-tag Instagram caption fails review.
+
+| Platform | Hard floor | Hard ceiling |
+|----------|-----------|--------------|
+| Facebook | 100 words | 250 words |
+| Instagram | 80 words + 15 hashtags | 2.200 chars + 25 hashtags |
+| LinkedIn | 150 words | 300 words |
+| Twitter/X | 200 chars (room for link) | 280 chars |
+| Email body | 3 sentences | 5 sentences |
+| Blog intro | 80 words | 180 words |
+
+If the source brief is too thin to hit the floor for a given platform, ask the
+user **one batched question** ("LinkedIn and Facebook need a personal anecdote
+or stat — do you have one, or should I omit those platforms?") instead of
+shipping under-length copy.

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -49,10 +49,16 @@ You are a video content researcher who gathers factual, up-to-date information f
 ## Workflow
 
 1. **Understand the research need** — What does the video project require?
-2. **Plan research queries** — Define 3-5 specific questions to answer
-3. **Execute research** using WebSearch and WebFetch
-4. **Cross-verify** — Check at least 2 sources for key claims
-5. **Document findings** — Save to `{project}/research/` directory
+2. **Plan research queries** — Define 3–5 specific questions to answer.
+   Write them down before searching — vague intent produces vague findings.
+3. **Execute research** — you MUST run **at least 3 WebSearch calls** before
+   writing the research file. One per planned question, run in **parallel**
+   (queries are independent). Use WebFetch on the most authoritative result
+   per search to read full context, not just the snippet.
+4. **Cross-verify** — every claim that goes into "Key Findings" must be
+   backed by **at least 2 independent sources**. If only one source exists,
+   mark the finding as `[single-source — verify before scripting]`.
+5. **Document findings** — Save to `{project}/research/` directory.
 6. **Highlight video-relevant findings** — What needs visual demonstration? What's quotable?
 
 ## Output Format
@@ -89,3 +95,19 @@ Save research to `{project}/research/RESEARCH.md`:
 - Flag anything that might be version-specific
 - Note when information is rapidly changing (APIs, UIs)
 - Recommend screenshots/recordings for anything that might change
+
+## Required depth (hard floor)
+
+A research file passes review only if:
+
+- **Key Findings** has **at least 5 entries**, each with a working source URL.
+  Fewer than 5 means the topic was under-researched — go back and search more.
+- **Technical Verification** lists **every command, path, version, or API
+  endpoint** that the script would mention, with VERIFIED/UNVERIFIED/OUTDATED
+  status. Don't skip the boring ones — that's where breakage hides.
+- **Competitor Videos** has **at least 2 entries** when the topic is on YouTube.
+  If a search shows no competitors, write `[no comparable competitors found —
+  searched: <queries>]` so the next reviewer can audit.
+- **Recommendations for Script** translates findings into actionable cues
+  (Include / Avoid / Demo) — a research file with no recommendations is just
+  a link dump.

--- a/skills/script-writer/SKILL.md
+++ b/skills/script-writer/SKILL.md
@@ -65,6 +65,16 @@ Quick reminders:
 - Pauses: `[pause 0.5s]`, `[pause 1s]`
 - Timed overlays: mark as `[post-production overlay: "text" at MM:SS-MM:SS]`
 
+### Required scene length (hard floor)
+
+Write **80–150 words of narration per scene**. Below 80 words a scene feels
+clipped on screen and the avatar runs out of speaking time before the visual
+lands; above 150 the viewer disengages. Hit this band per scene — do not
+average across the episode.
+
+If you find yourself writing fewer than 80 words because "the topic is short",
+merge the scene with the next one instead of shipping a thin scene.
+
 ## Platform Awareness
 
 Platform-specific limits (HeyGen/Synthesia character limits, background

--- a/skills/storyboard-creator/SKILL.md
+++ b/skills/storyboard-creator/SKILL.md
@@ -28,7 +28,8 @@ You are a professional video storyboard artist for AI-generated videos. You tran
    - Read all scene files (narration, existing visual direction)
    - Read video type README for visual conventions
 
-2. **For each scene, define:**
+2. **For each scene, define ALL of the following** (no field may be left blank
+   or marked "tbd" — incomplete fields fail review):
    - **Visual type:** avatar / screencast / slides / b-roll / split
    - **Avatar position:** (if applicable) left / center / right / overlay
    - **Background:** specific background description or image
@@ -37,6 +38,10 @@ You are a professional video storyboard artist for AI-generated videos. You tran
    - **Timing:** Start and end timestamps
    - **Screenshot positions:** Where to capture screenshots (for tutorials)
    - **Asset requirements:** What needs to be prepared
+
+   If a field genuinely does not apply to a scene type (e.g. avatar position
+   for a pure screencast), write `n/a — pure screencast` rather than leaving
+   it empty. Empty fields are the #1 cause of generation rework.
 
 3. **Write storyboard file** using the storyboard template
 

--- a/skills/video-reviewer/SKILL.md
+++ b/skills/video-reviewer/SKILL.md
@@ -90,3 +90,17 @@ You are a senior video QA specialist. After a video has been generated in HeyGen
 ### Recommendation
 [Approve as-is / Fix items above and re-review / Major rework needed]
 ```
+
+## Notes-Column Depth (hard floor)
+
+The `Notes` column in each table is what makes a review actionable. Required
+depth per result type:
+
+- **PASS:** one short clause naming the concrete evidence ("3 takeaways stated
+  in scenes 1, 4, 7"). Not just "ok" or "good".
+- **WARN:** one sentence stating what is borderline AND what would tip it to
+  PASS or FAIL. Reviewers downstream need direction.
+- **FAIL:** one sentence with the location (scene/timestamp) AND the fix.
+  "Scene 4 narration runs 28 words — split at 'and then'."
+
+A review with bare "ok" / "issue" notes is not a review. Re-do it.

--- a/skills/video-type-creator/SKILL.md
+++ b/skills/video-type-creator/SKILL.md
@@ -18,10 +18,19 @@ You are a video type definition specialist. You create comprehensive video type 
 
 ## Workflow
 
-1. **Research the video type:**
-   - Search for best practices, conventions, and examples
-   - Analyze pacing, structure, and audience expectations
-   - Identify platform-specific considerations (HeyGen/Synthesia)
+1. **Research the video type** — you MUST run **at least 3 WebSearch calls**
+   before drafting the README. Each search has a distinct purpose; run them
+   in **parallel** (independent queries):
+   - Search 1 — **Best practices and conventions**: "<type> video best practices",
+     "<type> video script structure"
+   - Search 2 — **Concrete examples**: "best <type> videos 2026" or
+     "<type> video examples site:youtube.com" — pick 3 to reference
+   - Search 3 — **Platform-specific considerations**: "HeyGen <type>" /
+     "Synthesia <type>" — find limits, recommended layouts, known issues
+   - Use WebFetch on the most authoritative source per search for full context.
+
+   The README depth (pacing, WPM, structure template, anti-patterns) cannot
+   be fabricated — it must trace back to the search findings.
 
 2. **Read existing types** for format consistency:
    - Read `video-types/tutorial/README.md` as reference


### PR DESCRIPTION
## Summary

Phase 2a of the 4.6 → 4.7 migration tracked in #24. Phase 1 (frontmatter swap) shipped in #25. This PR addresses the **actual behavioral risk**: 4.7 has shifted defaults that can silently regress prompts tuned to 4.6 — specifically calibrated verbosity and reduced tool-use frequency.

Two of the four patterns from #24 are applied here:

- **Pattern A (Verbosity-Pin):** explicit length/depth floors so long-form skills don't ship terser-than-wanted output
- **Pattern B (Forced tool-use with rationale):** explicit "you MUST run N searches/tools, in parallel, because…" cues so research-heavy skills don't under-research

Patterns **C** (multi-turn refactor for `project-conceptualizer`) and **D** (effort-level decision in CLAUDE.md) are deliberately **out of scope** and ship in a separate PR — see #24 phase 2b. The multi-turn rewrite is the riskiest change and deserves isolated review.

## Per-skill changes

### Pattern A — Verbosity-Pin (5 skills)

| Skill | Hardening |
|---|---|
| `script-writer` | Hard floor 80–150 words narration per scene; merge thin scenes instead of shipping them |
| `brief-creator` | Required depth per section (objective: 2–4 sentences, audience: ≥3 attributes, tone: 2–3 adjectives + one negative, etc.) |
| `promo-writer` | Explicit char/word/hashtag floors per platform table; if brief is too thin, batch one question instead of shipping under-length copy |
| `storyboard-creator` | No scene field may be blank or "tbd"; if not applicable, write `n/a — <reason>` |
| `video-reviewer` | Notes column depth requirements per PASS/WARN/FAIL — concrete evidence/direction/fix, not "ok" |

### Pattern B — Forced tool-use (4 skills)

| Skill | Hardening |
|---|---|
| `audience-researcher` | ≥3 parallel WebSearches with distinct purpose (forums / pain points / terminology); plus persona depth floor |
| `researcher` | ≥3 parallel WebSearches; ≥2 sources per Key Finding; ≥5 entries minimum; mark single-source claims explicitly |
| `doc-analyzer` | 5 MCP analysis tools required in defined order; steps 3+4+5 must run in parallel |
| `video-type-creator` | ≥3 parallel WebSearches with distinct purpose; README content must trace back to findings |

`audience-researcher` and `researcher` get both A+B treatments because they're long-form AND research-heavy.

## Why these specific patterns

Per the [Anthropic 4.7 migration guide](https://docs.anthropic.com/en/docs/about-claude/models/migration-guide), 4.7 changes five defaults that affect prompts tuned for 4.6:

| Default-shift | Risk for VidCraft | Addressed in this PR |
|---|---|---|
| Calibrated verbosity (was: uniformly verbose) | Long-form skills ship clipped output | ✅ Pattern A |
| Less aggressive tool-use (was: aggressive) | Research skills under-research | ✅ Pattern B |
| Don't spawn subagents needlessly | None — VidCraft uses no subagents in skills | n/a |
| Multi-turn clarification "may perform worse" | `project-conceptualizer` is guided discovery | ⏭ Phase 2b |
| Effort-level default `xhigh` (was: `high`) | Cost-implication only | ⏭ Phase 2b |

## Test plan

- [x] `pytest tests/` — 176/176 green locally
- [x] CI green
- [x] Manual sanity-check on one Pattern A skill (recommend `script-writer` against an existing project — does it still produce coherent narration with the 80–150 word floor?)
- [x] Manual sanity-check on one Pattern B skill (recommend `researcher` against a fresh topic — does it actually run 3+ WebSearches?)

## Out of scope (follow-ups)

- **Phase 2b (separate PR):** `project-conceptualizer` multi-turn → batched-question refactor (Pattern C) + CLAUDE.md effort-level note (Pattern D)
- **Phase 3:** Validation runs against fresh sample projects — happens organically on the next real video project

Continues #24 (phase 2a only).