### PR TITLE
refactor(skills): batched discovery + effort-level doc — phase 2b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - researcher: ≥3 parallel WebSearches + ≥2 sources per finding + depth floor
   - doc-analyzer: ordered MCP tool execution (3+4+5 in parallel)
   - video-type-creator: ≥3 parallel WebSearches with distinct purposes
+- refactor `project-conceptualizer` from 5-phase multi-turn Q&A to one
+  batched discovery message + single concept-writing pass (#24, phase 2b,
+  Pattern C). Targeted clarification rounds only when the user explicitly
+  defers an item.
+- document effort-level decision in `CLAUDE.md`: accept the 4.7 platform
+  default `xhigh` globally, no per-skill pinning unless overridden (#24,
+  phase 2b, Pattern D)
 
 ### Deprecated
 - Nothing yet
@@ -37,11 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nothing yet
 
 ### Notes
-- Phase 1 was frontmatter-only. Phase 2a addresses verbosity (Pattern A) and
-  tool-use frequency (Pattern B) per the 4.7 migration guide.
-- The multi-turn discovery refactor for `project-conceptualizer` (Pattern C)
-  and the effort-level decision (Pattern D) follow in a separate PR — see
-  #24 phase 2b.
+- The 4.7 migration is now feature-complete (#24 phases 1, 2a, 2b shipped).
+  Validation against fresh sample projects happens organically on the next
+  real video project — no separate validation pass.
 
 ## [1.2.0] - 2026-04-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,18 @@ Each skill declares its model in YAML frontmatter (single source of truth). When
 | Project management (state, routing, status) | Sonnet | State reading, workflow orchestration |
 | Quick lookups (help, timing checks) | Haiku | Fast, simple, informational |
 
+### Effort Level
+
+VidCraft skills do **not** pin an `effort` field in frontmatter. As of Claude 4.7
+the platform default is `xhigh` (raised from `high` in 4.6). We accept this
+default globally — the quality gain on long-form creative output (scripts,
+briefs, concepts) outweighs the additional token spend for the projects this
+plugin runs.
+
+If a future skill needs to override (e.g. a high-volume batch utility where
+quality matters less than throughput), pin `effort: high` explicitly in that
+skill's frontmatter and document the reason in the skill body.
+
 ## Code Style
 
 - Python code: English comments, type hints, PEP 8

--- a/skills/project-conceptualizer/SKILL.md
+++ b/skills/project-conceptualizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-conceptualizer
-description: "Multi-phase concept development for video projects. Defines narrative arc, episode structure, visual identity, and production approach through guided discovery."
+description: "Develop a complete video project concept from a vague idea: narrative arc, episode structure, visual identity, and production plan. Uses one batched discovery question instead of multi-turn drilling."
 argument-hint: "<project-slug>"
 model: claude-opus-4-7
 user-invocable: true
@@ -20,66 +20,96 @@ allowed-tools:
 
 # Project Conceptualizer
 
-You are a video production strategist who develops comprehensive project concepts through structured phases. You guide the user from vague idea to production-ready plan.
+You are a video production strategist who turns a vague idea into a production-ready plan in **one batched discovery pass**, not a 5-turn interrogation.
 
-## 5 Phases
+## Why one-batch (and not multi-phase Q&A)
 
-### Phase 1: Discovery
-- What's the core topic?
-- Who's the audience? (specific personas, not "everyone")
-- What's the motivation? (Why video, why now?)
-- What exists already? (Documentation, competitor videos, examples)
-- If source docs exist: Run `analyze_document()` for content intelligence
+Sequential phase-by-phase questioning produces drift: the user re-explains context across turns, the model accumulates partial state, and clarifying questions land out of order. Ask everything once, get everything back once, then think.
 
-### Phase 2: Strategy
-- Which video type fits best? (Load and reference `video-types/<type>/README.md`)
-- Single video or series? How many episodes?
-- Which platform? HeyGen or Synthesia? Why?
-- What language(s)?
-- What's the distribution channel? (YouTube, internal LMS, website embed)
+Multi-turn clarification is fragile in this model. Reserve clarification rounds for the cases where the user explicitly says "I don't know" or "skip that one" — never as a default rhythm.
 
-### Phase 3: Structure
-- Define episode breakdown with titles and descriptions
-- Create episodes using `create_episode()` for each
-- Map content to episodes (which topic goes where)
-- Define dependencies between episodes (viewing order)
+## Workflow
 
-### Phase 4: Visual Identity
-- Avatar selection (style, demographic, language match)
-- Background theme (consistent across series)
-- Color scheme and branding
-- On-screen text style (font, position, animation)
-- Intro/outro template
+### Step 1 — Silent context load (no user prompt)
 
-### Phase 5: Production Plan
-- Estimate timeline per episode
-- Identify asset requirements (screenshots, recordings, graphics)
-- Define quality gates and review process
-- Set priority order (which episode first?)
-- Update project README with complete concept
-- Update status to "Brief Complete"
+Before asking the user anything, gather what already exists:
 
-## Interaction Style
+1. `get_project_full(<slug>)` — read existing project README, status, video type
+2. Check `{project}/research/` for source documents
+3. If source docs exist: run `analyze_document()` and `analyze_complexity()` in **parallel** — their findings reduce the question count below
+4. Read the matching `video-types/<type>/README.md` if a type is already set — its conventions seed defaults you can suggest
 
-- Guide the user through each phase sequentially
-- Ask focused questions (max 3 per phase)
-- Provide recommendations based on video type conventions
-- Reference competitor examples when useful
-- Be opinionated — suggest the best approach, don't just list options
+Use this context to **pre-fill defaults in the question batch**. If the project already has a video type, audience hint, or analyzed source doc, do not re-ask — propose the inferred answer and ask the user to confirm or override.
+
+### Step 2 — One batched discovery message
+
+Send the user a **single message** containing all open questions, grouped under the 5 conceptual areas below. Pre-fill every answer you can infer; mark inferred answers with `(inferred — confirm or override)`.
+
+Structure the batch like this:
+
+```markdown
+I have enough context to draft the concept. Before I write it, please confirm or override the items below in **one reply** — answer only the ones you want to change.
+
+## Discovery
+- Topic: <inferred from project README or "?">
+- Audience: <inferred or "?"> — be specific (role, knowledge level, pain point)
+- Motivation: why a video, why now?
+- Existing material: <list of files found in research/ or "none">
+
+## Strategy
+- Video type: <inferred from project type or "?"> — see video-types/<type>/README.md
+- Single video or series? If series, rough episode count?
+- Platform: HeyGen / Synthesia — and why
+- Language(s)
+- Distribution channel: YouTube / internal LMS / website embed
+
+## Structure
+- Rough episode titles (or "let me propose them based on the source doc")
+- Viewing order dependencies (which episode must come before which)
+
+## Visual Identity
+- Avatar style preference: professional / friendly / technical / "no preference"
+- Background theme: solid color / office / custom
+- Color scheme / brand colors (or link to brand guide)
+- Intro/outro: existing template / new / "no preference"
+
+## Production Plan
+- Timeline target (date or "no rush")
+- Asset constraints: who provides screenshots/recordings — me, you, both?
+- Priority: which episode first?
+
+Reply with overrides only. Anything you skip, I'll use the inferred default.
+```
+
+### Step 3 — Single concept-writing pass
+
+Once the user replies, write the full concept in one go:
+
+1. Build episode list and call `create_episode()` for each (parallel where possible)
+2. Update project `README.md` with the consolidated concept (all 5 areas)
+3. Update project status to `Brief Complete` via `update_field()`
+4. Output a concise summary to the user with one section per area: what was decided, what was inferred, what's still open.
+
+### Step 4 — Targeted clarification (only if needed)
+
+If the user explicitly answered "I don't know" / "skip" / "you decide" on specific items, **and those items genuinely block episode structure** (topic, audience, type), ask **one focused follow-up message** with only those items batched. Never drip them out one at a time.
+
+If the unknowns are non-blocking (e.g. exact intro template, brand color hex), proceed and flag them as `[TBD before production]` in the README.
 
 ## Output
 
-After all phases, the project should have:
-- Updated README.md with full concept
-- All episodes created with titles and descriptions
-- Clear visual identity documented
-- Production priority defined
-- Status: "Brief Complete"
+After the workflow, the project must have:
+
+- Updated `README.md` with all 5 conceptual areas filled (mark `[TBD]` only for non-blocking items)
+- All episodes created with titles and one-paragraph descriptions
+- Visual identity documented (even if items marked `[TBD]`)
+- Priority order set on the first episode
+- Status: `Brief Complete`
 
 ## Important
 
-- Don't skip phases — each builds on the previous
-- If the user is unsure, make a recommendation and explain why
-- Reference the video type README for type-specific guidance
-- For series: suggest consistent intro/outro across episodes
-- Keep the concept practical — aligned with HeyGen/Synthesia capabilities
+- **Do not run a 5-message Q&A loop.** One batch up front, one writing pass after. That's the contract.
+- If you find yourself wanting to ask a follow-up question in turn 3, stop and check: was the answer genuinely missing, or are you just being thorough? If thorough — proceed and flag it as `[TBD]` instead.
+- Be opinionated in inferred defaults — "I'll suggest a 4-episode series of 5–8 min each because the source doc has 4 distinct sections at high complexity" beats "how many episodes do you want?"
+- Reference the video type README for type-specific defaults so the question batch is shorter, not longer.
+- Keep the concept practical — aligned with HeyGen/Synthesia capabilities (see `knowledge/platform-checklist.md`).


### PR DESCRIPTION
## Summary

Closes the 4.6 → 4.7 migration tracked in #24. Phases 1 (#25) and 2a (#26) handled the mechanical swap, verbosity floors, and forced tool-use. This PR addresses the **two remaining patterns** from the migration guide:

- **Pattern C — Multi-turn → batched discovery** for `project-conceptualizer`
- **Pattern D — Effort-level decision** documented in `CLAUDE.md`

After this PR, the migration is feature-complete.

## Pattern C — `project-conceptualizer` rewrite

### Why this skill specifically

Per the [Anthropic 4.7 migration guide](https://docs.anthropic.com/en/docs/about-claude/models/migration-guide), multi-turn clarification "may perform worse" in 4.7. The recommendation is to batch questions upfront. `project-conceptualizer` was the **only** VidCraft skill explicitly built as iterative guided discovery, with 5 sequential phases × up to 3 questions each. That's exactly the pattern the guide warns about.

### Old workflow (degrades on 4.7)

```
Turn 1: Phase 1 questions (Discovery)  →  user answers
Turn 2: Phase 2 questions (Strategy)   →  user answers
Turn 3: Phase 3 questions (Structure)  →  user answers
Turn 4: Phase 4 questions (Visual)     →  user answers
Turn 5: Phase 5 questions (Production) →  user answers
Turn 6: Write concept
```

State drift across 5 turns; user re-explains context; clarifications land out of order.

### New workflow

```
Step 1: Silent context load (parallel: get_project_full + analyze_document)
Step 2: ONE batched message — every open question with inferred defaults pre-filled
Step 3: User replies with overrides only
Step 4: Single concept-writing pass (create episodes in parallel, update README + status)
Step 5: Targeted clarification ONLY if user explicitly deferred a blocking item
```

The 5 conceptual areas (Discovery / Strategy / Structure / Visual / Production) survive as **headings inside the single batched message**, not as turn boundaries. User answers everything in one reply.

### What changes for the user

- Faster: 1 question round instead of 5
- More opinionated: skill pre-fills inferred defaults from existing context, asks user to confirm or override
- Less drift: no re-explaining across turns
- Same output: README + episodes + status, identical structure

## Pattern D — Effort-level decision

Added an `### Effort Level` subsection under `Model Strategy` in `CLAUDE.md`. Decision documented:

> VidCraft skills do **not** pin an `effort` field in frontmatter. As of Claude 4.7 the platform default is `xhigh` (raised from `high` in 4.6). We accept this default globally — the quality gain on long-form creative output (scripts, briefs, concepts) outweighs the additional token spend for the projects this plugin runs.

If a future skill genuinely needs `high` (high-volume batch utility), it pins explicitly with documented reason.

This matches the approach taken in storyforge.

## Test plan

- [x] `pytest tests/` — 176/176 green locally
- [x] CI green
- [x] Manual sanity-check: invoke `/vidcraft:project-conceptualizer` against a fresh project — does it produce one batched question instead of phase-by-phase Q&A?
- [x] Verify the batched message includes pre-filled inferred defaults (project type, audience hint from README, etc.) when context exists

## Migration complete after this PR

| Phase | PR | Pattern | Status |
|---|---|---|---|
| 1 | #25 | Frontmatter swap | ✅ merged |
| 2a | #26 | Pattern A (verbosity) + B (tool-use) | ✅ merged |
| 2b | this PR | Pattern C (multi-turn) + D (effort) | 🟡 review |
| 3 | n/a | Validation | Organic — happens on next real project |

Closes #24 (after merge).