### PR TITLE
fix: correct platform limits and HeyGen pause caveat

### DIFF
--- a/knowledge/platform-checklist.md
+++ b/knowledge/platform-checklist.md
@@ -16,19 +16,25 @@ see [`script-writing-rules.md`](script-writing-rules.md).
 |------------|--------|
 | One background per scene | One image, video, or color per HeyGen scene. Multiple backgrounds = split into multiple scenes. |
 | No timed text overlays | Overlays are visible for the entire scene duration. Timed overlays must be done in post-production. |
-| Max ~1500 characters per scene | Hard limit; split at natural pauses if exceeded. |
+| Max 5000 characters per scene | Hard API limit. AI Studio (copy/paste) auto-splits at ~1000 chars/segment — no manual splitting needed for length. Only split manually for background or avatar changes. |
 | Max scenes per video | Plan-dependent. Check current HeyGen plan. |
 | One avatar per scene | No multi-avatar scenes. |
 
 ### Pause Support
 
-HeyGen supports manual pauses inside narration:
+> **Important:** Pause markers and SSML tags only work with **Custom Voices** (voice clones,
+> ElevenLabs, OpenAI Voices). The public HeyGen Voice Library silently ignores all pause syntax.
 
-| Marker | HeyGen behavior |
-|--------|-----------------|
-| `[pause 0.5s]` | 0.5 second pause |
-| `[pause 1s]` | 1 second pause |
-| Paragraph break | ~0.5 second pause (default) |
+| Marker | HeyGen behavior | Requirement |
+|--------|-----------------|-------------|
+| `[pause 0.5s]` | 0.5 second pause | Custom Voice only |
+| `[pause 1s]` | 1 second pause | Custom Voice only |
+| Paragraph break | ~0.5 second pause (default) | All voices |
+
+**Fallback for public voices:** Use punctuation-based pacing instead:
+- `,` → short pause (~300ms)
+- `.` → longer pause (~600ms) with falling intonation
+- `-` → syllable break for pronunciation clarity
 
 The same syntax is used in the source scripts (see
 [`script-writing-rules.md`](script-writing-rules.md#pause-syntax)).
@@ -37,9 +43,11 @@ The same syntax is used in the source scripts (see
 
 Split a content scene when:
 
-- It exceeds 1500 characters
 - It needs more than one background
 - It needs to switch avatar
+
+> The 5000-char API limit is rarely hit in practice. AI Studio auto-splits long segments at ~1000
+> chars — no manual intervention needed for length alone.
 
 When splitting:
 
@@ -80,7 +88,7 @@ Each scene needs:
 | Constraint | Detail |
 |------------|--------|
 | Max ~1000 characters per slide | Slide-based; split at sentence boundary if exceeded. |
-| Max slides per video | 50+ (plan-dependent). |
+| Max scenes per video | 150 (PowerPoint import: also 150 slides). |
 | Languages | 130+ supported. |
 | Slide-based scene structure | 1 scene typically maps to 1 slide. |
 

--- a/servers/vidcraft-server/server.py
+++ b/servers/vidcraft-server/server.py
@@ -953,7 +953,9 @@ def heygen_format_script(
             block.append(f"Text Overlay: {on_screen}")
 
         block.append(f"\nScript:\n{narration}")
-        block.append(f"\nChars: {len(narration)}/5000 (API limit) — AI Studio auto-splits at ~1000 chars/segment")
+        block.append(
+            f"\nChars: {len(narration)}/5000 (API limit) — AI Studio auto-splits at ~1000 chars/segment"
+        )
         blocks.append("\n".join(block))
 
     return "\n\n".join(blocks)

--- a/servers/vidcraft-server/server.py
+++ b/servers/vidcraft-server/server.py
@@ -770,7 +770,7 @@ def validate_structure(
 # Platform character limits
 _PLATFORM_LIMITS = {
     "heygen": {
-        "max_chars_per_scene": 1500,
+        "max_chars_per_scene": 5000,
         "max_scenes": 100,
         "supported_formats": ["mp4"],
         "min_resolution": "720p",
@@ -779,7 +779,7 @@ _PLATFORM_LIMITS = {
     },
     "synthesia": {
         "max_chars_per_scene": 1000,
-        "max_scenes": 50,
+        "max_scenes": 150,
         "supported_formats": ["mp4"],
         "min_resolution": "720p",
         "max_resolution": "1080p",
@@ -953,7 +953,7 @@ def heygen_format_script(
             block.append(f"Text Overlay: {on_screen}")
 
         block.append(f"\nScript:\n{narration}")
-        block.append(f"\nChars: {len(narration)}/1500")
+        block.append(f"\nChars: {len(narration)}/5000 (API limit) — AI Studio auto-splits at ~1000 chars/segment")
         blocks.append("\n".join(block))
 
     return "\n\n".join(blocks)

--- a/skills/heygen-engineer/SKILL.md
+++ b/skills/heygen-engineer/SKILL.md
@@ -24,7 +24,7 @@ You are a HeyGen platform specialist. You optimize video content for HeyGen's ge
 
 1. **Load episode data** — all scenes, narration, visual direction
 2. **Check platform limits** — see `knowledge/platform-checklist.md` (HeyGen section)
-   for the authoritative list (one background per scene, ~1500 chars, pause syntax)
+   for the authoritative list (one background per scene, 5000 char API limit, pause syntax)
 3. **Select avatar** based on project brand, audience, language
 4. **Format script** for HeyGen's scene structure
 5. **Generate clipboard output** for easy copy-paste into HeyGen
@@ -44,8 +44,8 @@ Key constraints to enforce here:
 
 - One background per HeyGen scene → split if more needed
 - Overlays are full-scene-duration only → timed overlays go to post-production
-- ~1500 characters per scene (hard limit)
-- Pauses: `[pause 0.5s]`, `[pause 1s]`
+- 5000 characters per scene (API hard limit); AI Studio auto-splits at ~1000 chars/segment
+- Pauses: `[pause 0.5s]`, `[pause 1s]` — **custom voices only**, public voice library ignores pause syntax
 
 ## Avatar Selection
 
@@ -66,8 +66,10 @@ After avatar is selected, document in episode README.
 ## Character Limit Optimization
 
 Split a scene when:
-- It exceeds 1500 characters
 - It requires multiple backgrounds (one background per HeyGen scene!)
+- It requires an avatar switch
+
+> The 5000-char API limit is rarely reached. AI Studio auto-splits long scenes at ~1000 chars — no manual split needed for length alone.
 
 When splitting:
 1. Split at a natural pause point in the narration

--- a/skills/script-writer/SKILL.md
+++ b/skills/script-writer/SKILL.md
@@ -82,7 +82,7 @@ rules, overlay timing) are in `knowledge/platform-checklist.md`.
 
 Quick reminders:
 
-- **HeyGen:** one background per scene, no timed overlays, ~1500 chars per scene
+- **HeyGen:** one background per scene, no timed overlays, 5000 chars/scene API limit (Studio auto-splits at ~1000); pauses only work with custom voices
 - **Synthesia:** slide-based, ~1000 chars per slide, 130+ languages
 
 ## Anti-Patterns to Avoid


### PR DESCRIPTION
## Summary

- Corrects three wrong data points that blocked or misled users (Issues #28, #29, #30)
- All 176 tests pass

## Changes

**HeyGen character limit (#28)**
- `max_chars_per_scene`: 1500 → 5000 (actual API hard limit)
- AI Studio auto-splits at ~1000 chars/segment — no manual splitting needed for length
- `heygen_format_script()` output updated to show `/5000 (API limit)` with Studio note
- Split guidance updated: only split for background/avatar changes, not character count

**Synthesia scene limit (#29)**
- `max_scenes`: 50 → 150 (actual platform limit, matches PowerPoint import limit)

**HeyGen pause syntax caveat (#30)**
- Pause markers (`[pause 0.5s]`, SSML `<break>`) only work with **custom voices**
- Public voice library silently ignores all pause syntax
- Added punctuation-based pacing fallback documented for public voices
- Updated `platform-checklist.md`, `heygen-engineer` skill, and `script-writer` skill

## Test plan

- [x] 176 unit tests green (`/home/markus/.vidcraft/venv/bin/pytest tests/ -q`)
- [x] Manually verify `validate_platform_limits()` no longer warns at 1500 chars for HeyGen
- [x] Manually verify `validate_platform_limits()` accepts 100+ scenes for Synthesia

Closes #28, Closes #29, Closes #30