### PR TITLE
feat: platform feature parity — SSML, gestures, Express-2, Voice Director, Avatar IV

### DIFF
--- a/knowledge/platform-checklist.md
+++ b/knowledge/platform-checklist.md
@@ -70,6 +70,42 @@ Kdenlive / Premiere:
 Mark these in scene scripts using the `[post-production ...]` syntax
 (see [`script-writing-rules.md`](script-writing-rules.md#timed-overlays-post-production-marker)).
 
+### Voice Director
+
+Control vocal tone per scene via **emotion presets** or natural language prompts (HeyGen AI Studio → Voice → Voice Director).
+
+| Preset | Best For |
+|--------|----------|
+| `Casual` | Tutorials, developer content |
+| `Calm` | Support, step-by-step explanations |
+| `Excited` | Product launches, CTAs |
+| `Serious` | Compliance, authoritative content |
+| `Cool` | Thought leadership, brand |
+
+Free-form alternative: `"Speak in a warm, encouraging tone."` — set as a natural language prompt.
+
+Recommendation: always set Voice Director explicitly; the default neutral tone rarely matches the content mood.
+
+### Avatar IV — Motion Prompts
+
+HeyGen Avatar IV (May 2025) supports custom gesture control via natural language **Motion Prompts**.
+
+**Syntax:** `[Body part] + [Action] + [Emotion/Intensity]`
+
+```
+"Right arm raises to wave enthusiastically."
+"Nods gently to emphasize agreement."
+"Points forward with confidence."
+"Looks surprised and raises eyebrows."
+"Avatar smiles softly while raising a hand."
+```
+
+**Rules:**
+- One short sentence per prompt — no compound actions
+- Available verbs: point, nod, turn, wave, smile, look surprised, smile gently
+- Set in HeyGen AI Studio → Avatar → Motion Prompt field (per scene)
+- Only available for Avatar IV avatars — check avatar generation when selecting
+
 ### HeyGen Scene Format
 
 Each scene needs:
@@ -78,8 +114,9 @@ Each scene needs:
 - **Avatar** selection (see `/vidcraft:avatar-selector`)
 - **Background** — exactly one per scene
 - **Avatar position** — left, center, or right
-- **Voice** selection
+- **Voice** selection + **Voice Director** preset or prompt
 - **Speed** — 0.8x to 1.2x
+- **Motion Prompt** (Avatar IV only, optional)
 
 ## Synthesia
 
@@ -110,6 +147,39 @@ Split a slide when it exceeds 1000 characters:
 1. Cut at a natural sentence break
 2. Use a transition slide for continuity
 3. Keep related content on adjacent slides
+
+### Gesture Tags (Express-1 avatars only)
+
+Embed inline gesture tags in script text to trigger avatar animations:
+
+```
+[gesture:nod]        — Nod (agreement)
+[gesture:headyes]    — Head up/down twice
+[gesture:headno]     — Head left/right (disagreement)
+[gesture:eyebrowsup] — Raised eyebrows (surprise/emphasis)
+[gesture:increase]   — Arm gesture for growth/expansion
+```
+
+Example: `"We are seeing [gesture:increase] huge growth this quarter."`
+
+**Important:** Gesture tags are only for **Express-1** avatars. Express-2 generates gestures automatically — do not add gesture tags to Express-2 scripts.
+
+### Express-2 Avatars (September 2025)
+
+Synthesia released Express-2 — a Diffusion Transformer-based model that changes how gestures and expressions work.
+
+| Feature | Express-1 | Express-2 |
+|---------|-----------|-----------|
+| Gestures | Manual `[gesture:tag]` syntax | Automatic from script context |
+| Expressions | Sentiment-driven | Full-body co-speech gestures |
+| Body language | Upper-body only | Full-body movement |
+| Script requirements | Explicit gesture tags | Strong verbs + concrete actions |
+
+**Writing for Express-2:**
+- No gesture tags needed — they will be ignored
+- Use active, concrete language: strong verbs and specific actions trigger gestures naturally
+- Passive/abstract scripts produce no gestures — avatar appears stiff
+- Example: "Click the button" (good) vs. "The button should be clicked" (stiff)
 
 ### Layout Templates
 

--- a/reference/heygen/api-reference.md
+++ b/reference/heygen/api-reference.md
@@ -74,6 +74,41 @@ Authorization: Bearer {api_key}
 
 API key from: HeyGen Dashboard → Settings → API
 
+## Voice Director (2025)
+
+HeyGen's Voice Director feature controls vocal tone via emotion presets or free-form natural language prompts.
+
+### Emotion Presets
+
+| Preset | Use Case |
+|--------|----------|
+| `Excited` | High energy, product launches, CTAs |
+| `Casual` | Developer tutorials, onboarding, informal demos |
+| `Calm` | Support content, reassuring explanations |
+| `Cool` | Confident brand messaging, thought leadership |
+| `Serious` | Compliance training, authoritative announcements |
+| `Funny` | Playful content, light-hearted social videos |
+| `Angry` | Firm/forceful tone — use very sparingly |
+| `Sarcastic` | Ironic delivery — use with caution |
+
+### Natural Language Prompts
+
+Free-form prompts describe the desired delivery style:
+
+```
+"Speak in a calm, steady tone with a warm, encouraging vibe."
+"Enthusiastic but professional — like presenting at a conference."
+"Friendly and approachable, as if talking to a colleague."
+```
+
+**Usage:** Set in HeyGen AI Studio under Voice → Voice Director when configuring a scene.
+
+**Recommendation:** Match preset to video type:
+- Tutorial/How-To → `Casual` or `Calm`
+- Product Demo → `Excited` or `Cool`
+- Training/Compliance → `Serious`
+- Onboarding → `Friendly` (via natural language prompt)
+
 ## Rate Limits
 
 - 100 requests/minute for listing endpoints

--- a/reference/heygen/avatar-guide.md
+++ b/reference/heygen/avatar-guide.md
@@ -28,13 +28,31 @@ Choose avatars that match or resonate with your target audience:
 | **Small overlay** | During screencast — bottom-right corner |
 | **Hidden** | Pure screencast or text-only slides |
 
-## Gestures (HeyGen-specific)
+## Avatar IV — Motion Prompts (May 2025)
 
-HeyGen avatars support configurable gestures:
-- **Neutral:** Default stance, minimal movement
-- **Pointing:** Direct attention to on-screen elements
-- **Open hands:** Welcoming, explaining concepts
-- **Nodding:** Affirming, agreeing with viewer's experience
+HeyGen Avatar IV uses a Diffusion-inspired audio-to-expression engine. Custom gesture control is done via **Motion Prompts** — natural language sentences set per scene.
+
+**Syntax:** `[Body part] + [Action] + [Emotion/Intensity]`
+
+```
+"Right arm raises to wave enthusiastically."
+"Nods gently to emphasize agreement."
+"Points forward with confidence."
+"Looks surprised and raises eyebrows."
+"Avatar smiles softly while raising a hand."
+```
+
+**Rules:**
+- One short sentence — no compound actions per prompt
+- Available verbs: point, nod, turn, wave, smile, look surprised, smile gently
+- Set in HeyGen AI Studio → Avatar → Motion Prompt (per scene)
+- Only available for Avatar IV avatars — verify avatar generation before committing
+
+**Legacy gesture styles** (pre-Avatar IV) are still available as broad categories:
+- **Neutral** — Default stance, minimal movement
+- **Pointing** — Direct attention to on-screen elements
+- **Open hands** — Welcoming, explaining concepts
+- **Nodding** — Affirming tone
 
 ## Background Recommendations
 

--- a/reference/synthesia/api-reference.md
+++ b/reference/synthesia/api-reference.md
@@ -69,9 +69,43 @@ Synthesia provides a REST API (STUDIO API) for programmatic video creation. Whil
 
 Each element in `input[]` is one slide:
 - Max ~1000 characters per slide script
-- Max 50 slides per video
+- Max 150 slides per video
 - Slides can have different avatars and backgrounds
 - Transitions are automatic (cut between slides)
+
+## Gesture Tags (Express-1 avatars)
+
+Inline gesture tags can be embedded directly in `scriptText` to trigger avatar gestures at specific points.
+
+```
+[gesture:nod]          — Avatar nods (agreement/confirmation)
+[gesture:headyes]      — Head up/down twice
+[gesture:headno]       — Head left/right twice (disagreement)
+[gesture:eyebrowsup]   — Raised eyebrows (surprise/emphasis)
+[gesture:increase]     — Arm/hand gesture for growth/expansion
+```
+
+**Usage:**
+```
+"We are seeing [gesture:increase] huge growth this quarter."
+"Let me [gesture:nod] confirm that this is the correct approach."
+```
+
+**Constraints:**
+- Gesture tags only work with **Express-1 avatars** — Express-2 generates gestures automatically from script context, so gesture tags are neither needed nor supported
+- Use gestures sparingly — one per sentence at most
+- Tags are stripped from the final audio; they only trigger animation
+
+## SSML Support
+
+Synthesia supports a subset of SSML for fine-grained speech control:
+
+```xml
+<break time="1s"/>     — Pause for 1 second
+<break time="0.5s"/>   — Pause for 500ms
+```
+
+VidCraft formatters auto-convert `[pause Xs]` markers to `<break time="Xs"/>` — no manual conversion needed.
 
 ## Authentication
 

--- a/reference/synthesia/avatar-guide.md
+++ b/reference/synthesia/avatar-guide.md
@@ -2,11 +2,21 @@
 
 ## Avatar Types
 
-### Express Avatars
+### Express-1 Avatars
 - AI-generated, available immediately
 - 150+ options across demographics
 - Support 130+ languages natively
-- Best for: standard content, quick turnaround
+- Support inline `[gesture:tag]` syntax for manual gesture control
+- Best for: standard content, quick turnaround, gesture-heavy scripts
+
+### Express-2 Avatars (September 2025)
+- Diffusion Transformer-based model — significant upgrade over Express-1
+- **Automatic gestures:** Generated from script semantics — no `[gesture:tag]` needed
+- **Full-body movement:** Not limited to upper-body like Express-1
+- **Better expressions:** Co-speech micro-expressions and body language
+- Best for: natural-looking content where script quality drives avatar behavior
+- **Script requirement:** Use active voice and concrete actions — passive/abstract language produces stiff output
+- Note: `[gesture:tag]` syntax is ignored by Express-2 avatars
 
 ### Studio Avatars
 - Recorded from real actors

--- a/servers/vidcraft-server/server.py
+++ b/servers/vidcraft-server/server.py
@@ -65,6 +65,17 @@ def _now_utc() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+_PAUSE_RE = re.compile(r"\[pause\s+([\d.]+s)\]")
+
+
+def _convert_pauses_to_ssml(text: str) -> str:
+    """Replace [pause Xs] markers with SSML <break time="Xs"/> tags.
+
+    Both Synthesia and HeyGen (custom voice only) accept this SSML subset.
+    """
+    return _PAUSE_RE.sub(lambda m: f'<break time="{m.group(1)}"/>', text)
+
+
 # ===========================================================================
 # STATE MANAGEMENT TOOLS
 # ===========================================================================
@@ -929,7 +940,7 @@ def heygen_format_script(
 
     blocks: list[str] = []
     for name, scene in sorted(scenes.items(), key=lambda x: x[1].get("number", 0)):
-        narration = scene.get("narration", "").strip()
+        narration = _convert_pauses_to_ssml(scene.get("narration", "").strip())
         visual_type = scene.get("visual_type", "avatar")
         visual_dir = scene.get("visual_direction", "").strip()
         on_screen = scene.get("on_screen_text", "").strip()
@@ -951,6 +962,13 @@ def heygen_format_script(
 
         if on_screen:
             block.append(f"Text Overlay: {on_screen}")
+
+        if "<break" in narration:
+            block.append(
+                "Note: SSML <break> tags require a Custom Voice "
+                "(voice clone, ElevenLabs, or OpenAI Voice). "
+                "Public HeyGen Voice Library ignores them silently."
+            )
 
         block.append(f"\nScript:\n{narration}")
         block.append(
@@ -989,7 +1007,7 @@ def synthesia_format_script(
 
     slides: list[str] = []
     for name, scene in sorted(scenes.items(), key=lambda x: x[1].get("number", 0)):
-        narration = scene.get("narration", "").strip()
+        narration = _convert_pauses_to_ssml(scene.get("narration", "").strip())
         visual_type = scene.get("visual_type", "avatar")
         on_screen = scene.get("on_screen_text", "").strip()
         assets = scene.get("assets", "").strip()

--- a/skills/avatar-selector/SKILL.md
+++ b/skills/avatar-selector/SKILL.md
@@ -81,6 +81,26 @@ You are a casting director for AI-generated videos. You recommend the optimal av
 2. [Avatar C] — if multi-language is priority
 ```
 
+## Synthesia: Express-1 vs. Express-2
+
+When recommending a Synthesia avatar, also specify the **avatar generation**:
+
+| Generation | Gestures | Script Style | Use When |
+|-----------|---------|-------------|---------|
+| Express-1 | Manual `[gesture:tag]` syntax | Standard | Precise gesture control needed |
+| Express-2 (Sep 2025) | Automatic from script context | Active/concrete language required | Natural-looking content, full-body motion |
+
+For Express-2: warn the script team that passive/abstract language produces stiff output — active verbs are required to trigger gestures.
+
+## HeyGen: Avatar IV vs. Legacy
+
+When recommending a HeyGen avatar, check if it's an **Avatar IV** avatar:
+
+- **Avatar IV (May 2025):** Supports natural language Motion Prompts for per-scene gesture control
+- **Legacy avatars:** Only support broad gesture categories (Neutral, Pointing, etc.)
+
+Recommend Avatar IV when the project needs scene-specific gesture variety. Document the avatar generation in the project README.
+
 ## Important
 
 - Avatar choice significantly impacts viewer trust and engagement

--- a/skills/heygen-engineer/SKILL.md
+++ b/skills/heygen-engineer/SKILL.md
@@ -76,12 +76,50 @@ When splitting:
 2. Add a transition between the split scenes
 3. Maintain visual continuity
 
+## Voice Director
+
+For every scene, recommend a **Voice Director** setting from HeyGen AI Studio:
+
+| Video Type | Recommended Preset |
+|-----------|-------------------|
+| Tutorial / How-To | `Casual` |
+| Step-by-step explanation | `Calm` |
+| Product demo / CTA | `Excited` |
+| Compliance / Training | `Serious` |
+| Thought leadership | `Cool` |
+
+Alternatively use a natural language prompt: `"Warm and encouraging, like a patient instructor."`
+
+Document the Voice Director choice in the episode README under platform settings.
+See full preset list in `reference/heygen/api-reference.md`.
+
+## Avatar IV Motion Prompts
+
+When the project uses Avatar IV avatars, add a **Motion Prompt** per scene where gestures would enhance delivery:
+
+```
+"Points forward with confidence."      — during CTAs or key steps
+"Nods gently to emphasize agreement."  — when confirming something
+"Right arm raises to wave."            — intro/outro scenes
+```
+
+One sentence per prompt, no compound actions. Set in HeyGen AI Studio → Avatar → Motion Prompt.
+See full syntax in `reference/heygen/avatar-guide.md`.
+
+## SSML Pauses
+
+`[pause Xs]` in narration is auto-converted to `<break time="Xs"/>` by
+`heygen_format_script`. SSML break tags only work with **Custom Voices**
+(voice clone, ElevenLabs, OpenAI Voice) — the formatter adds a caveat note
+automatically when breaks are present.
+
 ## Output
 
 Provide:
 1. Formatted script ready for HeyGen (via `heygen_format_script`)
 2. Recommended avatar + voice settings
 3. Background recommendations per scene (one per scene!)
-4. Any character limit warnings
-5. **Post-Production Tasks** — timed text overlays with timestamps for Shotcut/Kdenlive
-6. Pause markers with second values (`[pause 0.5s]`, `[pause 1s]`)
+4. **Voice Director** preset or prompt per scene
+5. **Motion Prompts** per scene (Avatar IV only, where appropriate)
+6. Any character limit warnings
+7. **Post-Production Tasks** — timed text overlays with timestamps for Shotcut/Kdenlive

--- a/skills/synthesia-engineer/SKILL.md
+++ b/skills/synthesia-engineer/SKILL.md
@@ -33,9 +33,10 @@ You are a Synthesia platform specialist. You optimize video content for Synthesi
 
 ## Synthesia Slide Structure, Layouts, Character Limits
 
-The Synthesia slide format, layout templates, and character-limit
-splitting rules are defined in `knowledge/platform-checklist.md`
-(Synthesia section). Read it before formatting a script.
+The Synthesia slide format, layout templates, character-limit splitting rules,
+gesture tag syntax, and Express-2 guidance are defined in
+`knowledge/platform-checklist.md` (Synthesia section). Read it before
+formatting a script.
 
 Narration rules (max 20 words/sentence, active voice, pauses) are
 shared across platforms — see `knowledge/script-writing-rules.md`.
@@ -45,6 +46,20 @@ Key constraints to enforce here:
 - ~1000 characters per slide (hard limit) → split at sentence break
 - 1 scene typically maps to 1 slide
 - Choose layout per scene type (intro, explanation, screencast, etc.)
+
+## Gesture Tags vs. Express-2
+
+**Before adding gesture tags, check the avatar type:**
+
+- **Express-1:** Use `[gesture:nod]`, `[gesture:increase]` etc. in the script where natural
+- **Express-2:** Do NOT add gesture tags — they are ignored. Write active, concrete sentences instead (strong verbs trigger gestures automatically)
+
+See `reference/synthesia/api-reference.md` for the full gesture tag list and `reference/synthesia/avatar-guide.md` for Express-1 vs. Express-2 differences.
+
+## SSML Pauses
+
+`[pause Xs]` in narration is auto-converted to `<break time="Xs"/>` by the
+`synthesia_format_script` tool — no manual conversion needed.
 
 ## Output
 

--- a/tests/test_format_tools.py
+++ b/tests/test_format_tools.py
@@ -109,6 +109,7 @@ class TestSkillsReferencePlatformFormatters:
 # SSML auto-conversion (#37)
 # ---------------------------------------------------------------------------
 
+
 def _make_state_with_narration(narration: str) -> dict[str, Any]:
     """Minimal in-memory state for formatter tests."""
     return {
@@ -147,10 +148,10 @@ class TestConvertPausesToSsml:
     @pytest.mark.parametrize(
         "raw, expected",
         [
-            ("[pause 1s]", "<break time=\"1s\"/>"),
-            ("[pause 0.5s]", "<break time=\"0.5s\"/>"),
-            ("[pause 2s]", "<break time=\"2s\"/>"),
-            ("[pause 1.5s]", "<break time=\"1.5s\"/>"),
+            ("[pause 1s]", '<break time="1s"/>'),
+            ("[pause 0.5s]", '<break time="0.5s"/>'),
+            ("[pause 2s]", '<break time="2s"/>'),
+            ("[pause 1.5s]", '<break time="1.5s"/>'),
         ],
     )
     def test_single_pause_converted(self, raw: str, expected: str) -> None:
@@ -161,8 +162,8 @@ class TestConvertPausesToSsml:
         server = _load_server_module()
         text = "Click Save. [pause 1s] Now open the next step. [pause 0.5s] Done."
         result = server._convert_pauses_to_ssml(text)
-        assert "<break time=\"1s\"/>" in result
-        assert "<break time=\"0.5s\"/>" in result
+        assert '<break time="1s"/>' in result
+        assert '<break time="0.5s"/>' in result
         assert "[pause" not in result
 
     def test_no_pause_unchanged(self) -> None:
@@ -183,8 +184,8 @@ class TestSynthesiaFormatterSsmlConversion:
             server._cache, "get", lambda: _make_state_with_narration(narration)
         )
         result = server.synthesia_format_script("test-proj", "ep-01")
-        assert "<break time=\"1s\"/>" in result, (
-            "synthesia_format_script must convert [pause Xs] to <break time=\"Xs\"/>"
+        assert '<break time="1s"/>' in result, (
+            'synthesia_format_script must convert [pause Xs] to <break time="Xs"/>'
         )
         assert "[pause 1s]" not in result, (
             "Raw [pause Xs] must not appear in synthesia output"
@@ -199,8 +200,8 @@ class TestSynthesiaFormatterSsmlConversion:
             server._cache, "get", lambda: _make_state_with_narration(narration)
         )
         result = server.synthesia_format_script("test-proj", "ep-01")
-        assert "<break time=\"0.5s\"/>" in result
-        assert "<break time=\"2s\"/>" in result
+        assert '<break time="0.5s"/>' in result
+        assert '<break time="2s"/>' in result
         assert "[pause" not in result
 
 
@@ -220,8 +221,8 @@ class TestHeyGenFormatterSsmlConversion:
             server._cache, "get", lambda: _make_state_with_narration(narration)
         )
         result = server.heygen_format_script("test-proj", "ep-01")
-        assert "<break time=\"1s\"/>" in result, (
-            "heygen_format_script must convert [pause Xs] to <break time=\"Xs\"/>"
+        assert '<break time="1s"/>' in result, (
+            'heygen_format_script must convert [pause Xs] to <break time="Xs"/>'
         )
         assert "[pause 1s]" not in result, (
             "Raw [pause Xs] must not appear in HeyGen output"
@@ -241,9 +242,7 @@ class TestHeyGenFormatterSsmlConversion:
             "SSML break tags are present"
         )
 
-    def test_no_caveat_when_no_pauses(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_caveat_when_no_pauses(self, monkeypatch: pytest.MonkeyPatch) -> None:
         server = _load_server_module()
         narration = "Hello world. This is a clean script without pauses."
         monkeypatch.setattr(

--- a/tests/test_format_tools.py
+++ b/tests/test_format_tools.py
@@ -4,6 +4,9 @@ Ensures the platform-specific format tools (heygen_format_script,
 synthesia_format_script) are registered in server.py and referenced
 correctly from the corresponding skills. Guards against regressions
 after removal of the generic format_for_clipboard helper (issue #2).
+
+Also covers SSML auto-conversion (#37): [pause Xs] in narration must be
+converted to platform-specific SSML break tags before the output is returned.
 """
 
 from __future__ import annotations
@@ -11,6 +14,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -99,3 +103,152 @@ class TestSkillsReferencePlatformFormatters:
             f"{skill_name}/SKILL.md still references the removed "
             f"format_for_clipboard tool"
         )
+
+
+# ---------------------------------------------------------------------------
+# SSML auto-conversion (#37)
+# ---------------------------------------------------------------------------
+
+def _make_state_with_narration(narration: str) -> dict[str, Any]:
+    """Minimal in-memory state for formatter tests."""
+    return {
+        "projects": {
+            "test-proj": {
+                "slug": "test-proj",
+                "episodes_data": {
+                    "ep-01": {
+                        "scenes": {
+                            "01-scene": {
+                                "number": 1,
+                                "title": "Scene One",
+                                "narration": narration,
+                                "visual_type": "avatar",
+                                "on_screen_text": "",
+                                "visual_direction": "",
+                                "assets": "",
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+
+class TestConvertPausesToSsml:
+    """Unit tests for the _convert_pauses_to_ssml helper (#37)."""
+
+    def test_function_exists_in_server(self) -> None:
+        server = _load_server_module()
+        assert hasattr(server, "_convert_pauses_to_ssml"), (
+            "_convert_pauses_to_ssml must be defined in server.py"
+        )
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("[pause 1s]", "<break time=\"1s\"/>"),
+            ("[pause 0.5s]", "<break time=\"0.5s\"/>"),
+            ("[pause 2s]", "<break time=\"2s\"/>"),
+            ("[pause 1.5s]", "<break time=\"1.5s\"/>"),
+        ],
+    )
+    def test_single_pause_converted(self, raw: str, expected: str) -> None:
+        server = _load_server_module()
+        assert server._convert_pauses_to_ssml(raw) == expected
+
+    def test_multiple_pauses_converted(self) -> None:
+        server = _load_server_module()
+        text = "Click Save. [pause 1s] Now open the next step. [pause 0.5s] Done."
+        result = server._convert_pauses_to_ssml(text)
+        assert "<break time=\"1s\"/>" in result
+        assert "<break time=\"0.5s\"/>" in result
+        assert "[pause" not in result
+
+    def test_no_pause_unchanged(self) -> None:
+        server = _load_server_module()
+        text = "Hello world. This is a test."
+        assert server._convert_pauses_to_ssml(text) == text
+
+
+class TestSynthesiaFormatterSsmlConversion:
+    """synthesia_format_script must auto-convert [pause Xs] in output (#37)."""
+
+    def test_pause_converted_to_break_tag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server = _load_server_module()
+        narration = "Click Save. [pause 1s] The file is now updated."
+        monkeypatch.setattr(
+            server._cache, "get", lambda: _make_state_with_narration(narration)
+        )
+        result = server.synthesia_format_script("test-proj", "ep-01")
+        assert "<break time=\"1s\"/>" in result, (
+            "synthesia_format_script must convert [pause Xs] to <break time=\"Xs\"/>"
+        )
+        assert "[pause 1s]" not in result, (
+            "Raw [pause Xs] must not appear in synthesia output"
+        )
+
+    def test_multiple_pauses_all_converted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server = _load_server_module()
+        narration = "Step one. [pause 0.5s] Step two. [pause 2s] Step three."
+        monkeypatch.setattr(
+            server._cache, "get", lambda: _make_state_with_narration(narration)
+        )
+        result = server.synthesia_format_script("test-proj", "ep-01")
+        assert "<break time=\"0.5s\"/>" in result
+        assert "<break time=\"2s\"/>" in result
+        assert "[pause" not in result
+
+
+class TestHeyGenFormatterSsmlConversion:
+    """heygen_format_script must auto-convert [pause Xs] in output (#37).
+
+    HeyGen pause/SSML only works with Custom Voices. The formatter must
+    add a caveat note in the block output so the engineer is reminded.
+    """
+
+    def test_pause_converted_to_break_tag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server = _load_server_module()
+        narration = "Click Save. [pause 1s] The file is now updated."
+        monkeypatch.setattr(
+            server._cache, "get", lambda: _make_state_with_narration(narration)
+        )
+        result = server.heygen_format_script("test-proj", "ep-01")
+        assert "<break time=\"1s\"/>" in result, (
+            "heygen_format_script must convert [pause Xs] to <break time=\"Xs\"/>"
+        )
+        assert "[pause 1s]" not in result, (
+            "Raw [pause Xs] must not appear in HeyGen output"
+        )
+
+    def test_custom_voice_caveat_present_when_pauses_exist(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server = _load_server_module()
+        narration = "Open the menu. [pause 1s] Select Settings."
+        monkeypatch.setattr(
+            server._cache, "get", lambda: _make_state_with_narration(narration)
+        )
+        result = server.heygen_format_script("test-proj", "ep-01")
+        assert "Custom Voice" in result, (
+            "heygen_format_script must add a Custom Voice caveat when "
+            "SSML break tags are present"
+        )
+
+    def test_no_caveat_when_no_pauses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server = _load_server_module()
+        narration = "Hello world. This is a clean script without pauses."
+        monkeypatch.setattr(
+            server._cache, "get", lambda: _make_state_with_narration(narration)
+        )
+        result = server.heygen_format_script("test-proj", "ep-01")
+        # No SSML injected → no caveat needed
+        assert "<break" not in result


### PR DESCRIPTION
## Summary

Phase 2 of epic #40 — Platform Feature Parity (5 sub-issues, all p1).

- **#37** `_convert_pauses_to_ssml` helper added to `server.py`; both formatters now auto-convert `[pause Xs]` → `<break time="Xs"/>`. HeyGen formatter adds a Custom Voice caveat when SSML breaks are present.
- **#31** Synthesia gesture tags (`[gesture:nod]`, `[gesture:increase]` etc.) documented in `reference/synthesia/api-reference.md`, `knowledge/platform-checklist.md`, and `synthesia-engineer` skill.
- **#32** Synthesia Express-2 (Sep 2025) documented: prompt-based automatic gestures, full-body motion, script requirements. Express-1 vs. Express-2 decision guidance in `avatar-guide` and `avatar-selector` skill.
- **#34** HeyGen Voice Director (2025): 8 emotion presets + natural language prompts. Video-type recommendations in `reference/heygen/api-reference.md`, `platform-checklist.md`, and `heygen-engineer` skill.
- **#35** HeyGen Avatar IV Motion Prompts: natural language gesture syntax documented in `avatar-guide`, `platform-checklist.md`, `heygen-engineer`, and `avatar-selector`.

## Test plan

- [x] 11 new tests added (TDD red → green) covering `_convert_pauses_to_ssml` unit + both formatter integration tests
- [x] Full suite: 188/188 passing, no regressions
- [x] `[pause 1s]` in a scene narration → `heygen_format_script` returns `<break time="1s"/>` + Custom Voice note
- [x] `[pause 1s]` in a scene narration → `synthesia_format_script` returns `<break time="1s"/>`
- [x] Narration without pauses → no `<break` tags, no caveat

Closes #31
Closes #32
Closes #34
Closes #35
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)