### PR TITLE
fix(deps): sync venv and add requirements-dev.txt with pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest ruff
+          pip install -r requirements-dev.txt
+
+      - name: Audit dependencies for CVEs
+        run: |
+          pip-audit --requirement requirements.txt
 
       - name: Lint with ruff
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Dev dependencies (not required at runtime)
+-r requirements.txt
+
+pytest
+ruff
+pip-audit


### PR DESCRIPTION
## Summary

- Add `requirements-dev.txt` (includes `requirements.txt` + pytest, ruff, pip-audit)
- Update `ci.yml` to install from `requirements-dev.txt` instead of hardcoded `pip install pytest ruff`
- Add `pip-audit --requirement requirements.txt` as CVE gate in CI test job
- Local venv synced: mcp 1.23→1.27, pdfplumber 0.11.4→0.11.9, pypdf 6.9.1→6.10.2, python-docx 1.1.2→1.2.0, textstat 0.7.4→0.7.13, pyyaml 6.0.2→6.0.3

## Test plan

- [x] `pip install -r requirements-dev.txt --upgrade` runs clean
- [x] `pip-audit --requirement requirements.txt` — no vulnerabilities found
- [x] 213/213 tests pass after venv sync
- [x] CI installs from `requirements-dev.txt` (no more hardcoded tool list)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)