### PR TITLE
test: add tests/smoke/ — 4 mandatory smoke tests

### DIFF
--- a/tests/smoke/test_knowledge.py
+++ b/tests/smoke/test_knowledge.py
@@ -1,0 +1,109 @@
+"""Smoke test: knowledge/ and reference/ files are parseable and non-empty.
+
+Verifies the knowledge base that skills depend on is intact. A missing or
+corrupted knowledge file silently breaks skill behaviour.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
+KNOWLEDGE_DIR = PLUGIN_ROOT / "knowledge"
+REFERENCE_DIR = PLUGIN_ROOT / "reference"
+
+_KNOWLEDGE_FILES = sorted(KNOWLEDGE_DIR.rglob("*.md"))
+_REFERENCE_FILES = sorted(REFERENCE_DIR.rglob("*.md"))
+_ALL_KNOWLEDGE = _KNOWLEDGE_FILES + _REFERENCE_FILES
+
+REQUIRED_KNOWLEDGE_FILES = (
+    "ai-language-patterns.md",
+    "platform-checklist.md",
+    "script-writing-rules.md",
+    "status-workflow.md",
+)
+
+REQUIRED_REFERENCE_FILES = (
+    "state-schema.md",
+    "terminology.md",
+)
+
+
+class TestKnowledgeFilesExist:
+    def test_knowledge_directory_exists(self) -> None:
+        assert KNOWLEDGE_DIR.is_dir(), "knowledge/ directory missing"
+
+    def test_reference_directory_exists(self) -> None:
+        assert REFERENCE_DIR.is_dir(), "reference/ directory missing"
+
+    @pytest.mark.parametrize("filename", REQUIRED_KNOWLEDGE_FILES)
+    def test_required_knowledge_file_exists(self, filename: str) -> None:
+        assert (KNOWLEDGE_DIR / filename).exists(), (
+            f"Required knowledge file missing: knowledge/{filename}"
+        )
+
+    @pytest.mark.parametrize("filename", REQUIRED_REFERENCE_FILES)
+    def test_required_reference_file_exists(self, filename: str) -> None:
+        assert (REFERENCE_DIR / filename).exists(), (
+            f"Required reference file missing: reference/{filename}"
+        )
+
+
+class TestKnowledgeFilesReadable:
+    @pytest.mark.parametrize(
+        "md_path", _ALL_KNOWLEDGE, ids=lambda p: str(p.relative_to(PLUGIN_ROOT))
+    )
+    def test_file_is_readable(self, md_path: Path) -> None:
+        text = md_path.read_text(encoding="utf-8")
+        assert len(text.strip()) > 0, f"{md_path.name} is empty"
+
+    @pytest.mark.parametrize(
+        "md_path", _ALL_KNOWLEDGE, ids=lambda p: str(p.relative_to(PLUGIN_ROOT))
+    )
+    def test_file_has_heading(self, md_path: Path) -> None:
+        text = md_path.read_text(encoding="utf-8")
+        assert any(line.startswith("#") for line in text.splitlines()), (
+            f"{md_path.relative_to(PLUGIN_ROOT)}: no markdown heading found"
+        )
+
+    @pytest.mark.parametrize(
+        "md_path", _ALL_KNOWLEDGE, ids=lambda p: str(p.relative_to(PLUGIN_ROOT))
+    )
+    def test_file_is_valid_utf8(self, md_path: Path) -> None:
+        try:
+            md_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as e:
+            pytest.fail(f"{md_path.name}: UTF-8 decode error — {e}")
+
+
+class TestSkillKnowledgeReferences:
+    """Key skills must reference the canonical knowledge files."""
+
+    @pytest.mark.parametrize(
+        "skill_name",
+        ["script-writer", "heygen-engineer", "storyboard-creator"],
+    )
+    def test_script_writing_rules_referenced(self, skill_name: str) -> None:
+        skill_path = PLUGIN_ROOT / "skills" / skill_name / "SKILL.md"
+        text = skill_path.read_text(encoding="utf-8")
+        assert "knowledge/script-writing-rules.md" in text, (
+            f"{skill_name}/SKILL.md must reference knowledge/script-writing-rules.md"
+        )
+
+    @pytest.mark.parametrize(
+        "skill_name",
+        [
+            "script-writer",
+            "heygen-engineer",
+            "synthesia-engineer",
+            "storyboard-creator",
+        ],
+    )
+    def test_platform_checklist_referenced(self, skill_name: str) -> None:
+        skill_path = PLUGIN_ROOT / "skills" / skill_name / "SKILL.md"
+        text = skill_path.read_text(encoding="utf-8")
+        assert "knowledge/platform-checklist.md" in text, (
+            f"{skill_name}/SKILL.md must reference knowledge/platform-checklist.md"
+        )

--- a/tests/smoke/test_mcp_server.py
+++ b/tests/smoke/test_mcp_server.py
@@ -1,0 +1,110 @@
+"""Smoke test: MCP server loads cleanly and all tool handlers are registered.
+
+Verifies the most critical invariant: the server can be imported without error
+and the expected minimum set of @mcp.tool() handlers is present.
+
+If this test fails, the plugin is completely broken for the user.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
+SERVER_PATH = PLUGIN_ROOT / "servers" / "vidcraft-server" / "server.py"
+
+_TOOL_DEF_RE = re.compile(
+    r"@mcp\.tool\(\)\s*\n\s*(?:async\s+)?def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(",
+    re.MULTILINE,
+)
+
+EXPECTED_MIN_TOOL_COUNT = 36
+
+
+def _load_server() -> Any:
+    plugin_root_str = str(PLUGIN_ROOT)
+    if plugin_root_str not in sys.path:
+        sys.path.insert(0, plugin_root_str)
+    spec = importlib.util.spec_from_file_location("vidcraft_smoke_server", SERVER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestMcpServerLoads:
+    """MCP server must import without error and register all tool handlers."""
+
+    def test_server_file_exists(self) -> None:
+        assert SERVER_PATH.exists(), f"server.py not found at {SERVER_PATH}"
+
+    def test_server_imports_without_error(self) -> None:
+        server = _load_server()
+        assert server is not None
+
+    def test_minimum_tool_count_in_source(self) -> None:
+        source = SERVER_PATH.read_text(encoding="utf-8")
+        tools = _TOOL_DEF_RE.findall(source)
+        assert len(tools) >= EXPECTED_MIN_TOOL_COUNT, (
+            f"Expected ≥{EXPECTED_MIN_TOOL_COUNT} @mcp.tool() handlers, "
+            f"found {len(tools)}: {tools}"
+        )
+
+    def test_core_tools_present_in_source(self) -> None:
+        source = SERVER_PATH.read_text(encoding="utf-8")
+        tools = set(_TOOL_DEF_RE.findall(source))
+        required = {
+            "list_projects",
+            "get_project_full",
+            "create_project_structure",
+            "create_episode",
+            "create_scene",
+            "update_field",
+            "get_plugin_version",
+            "rebuild_state",
+            "heygen_format_script",
+            "synthesia_format_script",
+            "validate_project_structure",
+            "run_pre_generation_gates",
+            "analyze_document",
+            "extract_key_points",
+            "suggest_video_structure",
+            "analyze_complexity",
+            "suggest_video_topics",
+        }
+        missing = required - tools
+        assert not missing, f"Missing required MCP tools: {missing}"
+
+    def test_server_has_path_validation_helper(self) -> None:
+        source = SERVER_PATH.read_text(encoding="utf-8")
+        assert "_assert_within_content_root" in source, (
+            "Security helper _assert_within_content_root missing — "
+            "file_path tools are unprotected (fix from #47)"
+        )
+
+    def test_file_path_tools_use_validation(self) -> None:
+        source = SERVER_PATH.read_text(encoding="utf-8")
+        file_path_tools = [
+            "update_field",
+            "extract_section",
+            "analyze_document",
+            "extract_key_points",
+            "suggest_video_structure",
+            "analyze_complexity",
+            "suggest_video_topics",
+        ]
+        for tool in file_path_tools:
+            # Slice the section of source that belongs to this tool function
+            start = source.find(f"def {tool}(")
+            assert start != -1, f"Tool {tool} not found in server.py"
+            # Next function starts at the next @mcp.tool() or end of file
+            next_tool = source.find("@mcp.tool()", start + 1)
+            section = source[start:next_tool] if next_tool != -1 else source[start:]
+            assert "_assert_within_content_root" in section, (
+                f"Tool '{tool}' does not call _assert_within_content_root — "
+                f"path validation missing (fix from #47)"
+            )

--- a/tests/smoke/test_skills.py
+++ b/tests/smoke/test_skills.py
@@ -1,0 +1,106 @@
+"""Smoke test: all skill SKILL.md files are valid and consistent.
+
+Checks required frontmatter fields, valid model IDs, no duplicate names,
+and that user-invocable is explicitly declared on every skill.
+
+If this fails, skills will be silently ignored or behave incorrectly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
+SKILLS_DIR = PLUGIN_ROOT / "skills"
+
+VALID_MODELS = frozenset(
+    {
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5-20251001",
+    }
+)
+
+REQUIRED_FIELDS = ("name", "description", "user-invocable", "model")
+
+_SKILL_FILES = sorted(SKILLS_DIR.glob("*/SKILL.md"))
+
+
+def _parse_frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---"), f"{path}: must start with YAML frontmatter"
+    end = text.index("---", 3)
+    return yaml.safe_load(text[3:end]) or {}
+
+
+class TestSkillCount:
+    def test_minimum_skill_count(self) -> None:
+        assert len(_SKILL_FILES) >= 33, (
+            f"Expected ≥33 skills, found {len(_SKILL_FILES)}"
+        )
+
+    def test_each_skill_dir_has_skill_md(self) -> None:
+        for skill_dir in SKILLS_DIR.iterdir():
+            if skill_dir.is_dir():
+                assert (skill_dir / "SKILL.md").exists(), (
+                    f"Skill directory '{skill_dir.name}' missing SKILL.md"
+                )
+
+    def test_skills_are_flat(self) -> None:
+        for skill_dir in SKILLS_DIR.iterdir():
+            if skill_dir.is_dir():
+                subdirs = [d for d in skill_dir.iterdir() if d.is_dir()]
+                assert not subdirs, (
+                    f"Skill '{skill_dir.name}' contains subdirectories — "
+                    f"skills must be flat: {[d.name for d in subdirs]}"
+                )
+
+
+class TestSkillFrontmatter:
+    @pytest.mark.parametrize("skill_path", _SKILL_FILES, ids=lambda p: p.parent.name)
+    def test_required_fields_present(self, skill_path: Path) -> None:
+        meta = _parse_frontmatter(skill_path)
+        missing = [f for f in REQUIRED_FIELDS if f not in meta]
+        assert not missing, (
+            f"{skill_path.parent.name}/SKILL.md missing fields: {missing}"
+        )
+
+    @pytest.mark.parametrize("skill_path", _SKILL_FILES, ids=lambda p: p.parent.name)
+    def test_model_is_valid(self, skill_path: Path) -> None:
+        meta = _parse_frontmatter(skill_path)
+        model = meta.get("model", "")
+        assert model in VALID_MODELS, (
+            f"{skill_path.parent.name}/SKILL.md: invalid model '{model}'. "
+            f"Valid models: {sorted(VALID_MODELS)}"
+        )
+
+    @pytest.mark.parametrize("skill_path", _SKILL_FILES, ids=lambda p: p.parent.name)
+    def test_user_invocable_is_boolean(self, skill_path: Path) -> None:
+        meta = _parse_frontmatter(skill_path)
+        value = meta.get("user-invocable")
+        assert isinstance(value, bool), (
+            f"{skill_path.parent.name}/SKILL.md: 'user-invocable' must be "
+            f"true or false (bool), got {type(value).__name__}: {value!r}"
+        )
+
+    @pytest.mark.parametrize("skill_path", _SKILL_FILES, ids=lambda p: p.parent.name)
+    def test_name_matches_directory(self, skill_path: Path) -> None:
+        meta = _parse_frontmatter(skill_path)
+        dir_name = skill_path.parent.name
+        skill_name = meta.get("name", "")
+        assert skill_name == dir_name, (
+            f"SKILL.md 'name: {skill_name}' does not match directory name '{dir_name}'"
+        )
+
+
+class TestSkillUniqueness:
+    def test_no_duplicate_skill_names(self) -> None:
+        names = []
+        for skill_path in _SKILL_FILES:
+            meta = _parse_frontmatter(skill_path)
+            names.append(meta.get("name", ""))
+        duplicates = [n for n in names if names.count(n) > 1]
+        assert not duplicates, f"Duplicate skill names: {sorted(set(duplicates))}"

--- a/tests/smoke/test_state.py
+++ b/tests/smoke/test_state.py
@@ -1,0 +1,180 @@
+"""Smoke test: state CRUD roundtrip — create → list → update → rebuild.
+
+Tests the core state management workflow that every user interaction depends on.
+Also verifies that path validation (fix from #47) is active in the write tool.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
+SERVER_PATH = PLUGIN_ROOT / "servers" / "vidcraft-server" / "server.py"
+
+
+def _make_config(content_root: Path) -> dict:
+    return {
+        "paths": {
+            "content_root": str(content_root),
+            "video_root": str(content_root / "videos"),
+            "assets_root": str(content_root / "assets"),
+            "overrides": str(content_root / "overrides"),
+        },
+        "defaults": {"language": ["de"], "wpm": 140, "platform": "heygen"},
+        "heygen": {"default_avatar": "", "default_voice": ""},
+        "synthesia": {"default_avatar": "", "default_voice": ""},
+        "brand": {"name": "Test Brand", "tone": ["professional"]},
+    }
+
+
+def _load_server(monkeypatch: pytest.MonkeyPatch, content_root: Path) -> Any:
+    plugin_root_str = str(PLUGIN_ROOT)
+    if plugin_root_str not in sys.path:
+        sys.path.insert(0, plugin_root_str)
+    spec = importlib.util.spec_from_file_location("vidcraft_smoke_state", SERVER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    config = _make_config(content_root)
+    monkeypatch.setattr(module, "load_config", lambda: config)
+    monkeypatch.setattr(module._cache, "invalidate", lambda: None)
+    return module
+
+
+class TestStateCrudRoundtrip:
+    """create_project_structure → list_projects → update_field → rebuild_state."""
+
+    @pytest.fixture()
+    def setup(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+        server = _load_server(monkeypatch, content_root)
+        return server, content_root
+
+    def test_create_project_structure(self, setup) -> None:
+        server, content_root = setup
+        result = server.create_project_structure("Smoke Test Project", "tutorial")
+        assert "created" in result.lower()
+        assert (content_root / "projects" / "smoke-test-project").is_dir()
+
+    def test_list_projects_after_create(
+        self, setup, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server, content_root = setup
+        server.create_project_structure("List Test Project", "tutorial")
+
+        state = {
+            "projects": {
+                "list-test-project": {
+                    "slug": "list-test-project",
+                    "title": "List Test Project",
+                    "status": "Concept",
+                    "video_type": "tutorial",
+                    "episode_count": 0,
+                }
+            }
+        }
+        monkeypatch.setattr(server._cache, "get", lambda: state)
+
+        result = server.list_projects()
+        assert "list-test-project" in result.lower() or "List Test Project" in result
+
+    def test_update_field_on_project_readme(self, setup) -> None:
+        server, content_root = setup
+        server.create_project_structure("Update Test Project", "tutorial")
+
+        readme = content_root / "projects" / "update-test-project" / "README.md"
+        assert readme.exists(), "create_project_structure must create README.md"
+
+        result = server.update_field(str(readme), "status", "Script Draft")
+        assert "updated" in result.lower() or "status" in result.lower(), (
+            f"update_field failed: {result}"
+        )
+
+        updated_text = readme.read_text(encoding="utf-8")
+        assert "Script Draft" in updated_text
+
+    def test_rebuild_state_runs_without_error(
+        self, setup, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server, content_root = setup
+        server.create_project_structure("Rebuild Test Project", "tutorial")
+
+        captured = {}
+
+        def fake_rebuild(**kwargs) -> dict:
+            captured["called"] = True
+            return {"projects": {}}
+
+        monkeypatch.setattr(server, "rebuild", fake_rebuild)
+        monkeypatch.setattr(server._cache, "invalidate", lambda: None)
+
+        result = server.rebuild_state()
+        assert "rebuilt" in result.lower() or captured.get("called"), (
+            f"rebuild_state did not run: {result}"
+        )
+
+
+class TestPathValidationActive:
+    """Verifies the #47 security fix is active in the state write tool."""
+
+    def test_update_field_rejects_path_outside_content_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+        server = _load_server(monkeypatch, content_root)
+
+        outside = tmp_path / "attacker" / "secret.md"
+        outside.parent.mkdir()
+        outside.write_text("---\nstatus: Concept\n---\n", encoding="utf-8")
+
+        result = server.update_field(str(outside), "status", "HACKED")
+        assert "outside content root" in result.lower(), (
+            "update_field must reject paths outside content_root — "
+            "_assert_within_content_root not applied (#47)"
+        )
+
+    def test_update_field_accepts_path_inside_content_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+        server = _load_server(monkeypatch, content_root)
+
+        valid = content_root / "projects" / "test" / "README.md"
+        valid.parent.mkdir(parents=True)
+        valid.write_text("---\nstatus: Concept\n---\n\n# Test\n", encoding="utf-8")
+
+        result = server.update_field(str(valid), "status", "Script Draft")
+        assert "outside content root" not in result.lower()
+
+
+class TestIdeasCrud:
+    """create_video_idea → get_video_ideas roundtrip."""
+
+    def test_create_and_retrieve_idea(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+        server = _load_server(monkeypatch, content_root)
+
+        create_result = server.create_video_idea(
+            title="Smoke Test Idea",
+            notes="A concept for smoke testing",
+        )
+        assert (
+            "smoke test idea" in create_result.lower()
+            or "created" in create_result.lower()
+        ), f"create_video_idea failed: {create_result}"
+
+        get_result = server.get_video_ideas()
+        # Returns JSON list when ideas exist, or a "No ideas yet" string otherwise
+        assert isinstance(get_result, str) and len(get_result) > 0


### PR DESCRIPTION
## Summary

Implements the claude-plugin CI-Mindestanforderung for `tests/smoke/`:

| File | Tests |
|------|-------|
| `test_mcp_server.py` | Server imports cleanly, ≥36 `@mcp.tool()` handlers registered, core tools present, `_assert_within_content_root` security helper active in all 7 file_path tools (#47) |
| `test_skills.py` | All 33 skills have required frontmatter (`name`, `description`, `user-invocable`, `model`), valid model IDs, `name` matches directory, no duplicate names |
| `test_knowledge.py` | All `knowledge/` and `reference/` files readable, non-empty, valid UTF-8, have a markdown heading; key skills reference canonical knowledge files |
| `test_state.py` | `create_project_structure → list_projects → update_field → rebuild_state` roundtrip; path validation (#47) verified active; ideas CRUD smoke |

## Test plan

- [x] 206 new tests — all passing
- [x] Full suite: 438/438 passing
- [x] `ruff check` + `ruff format` clean
- [x] Smoke tests run in under 1 second (`tests/smoke/ -q`: 0.76s)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)