### PR TITLE
chore: add mypy to venv and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           ruff format --check tools/ tests/ servers/
 
+      - name: Type check with mypy
+        run: |
+          mypy tools/ servers/ hooks/ --ignore-missing-imports
+
       - name: Run tests with coverage
         run: |
           python -m pytest tests/ -v --cov=tools --cov=servers --cov-fail-under=70

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest
 pytest-cov
 ruff
 pip-audit
+mypy

--- a/servers/vidcraft-server/server.py
+++ b/servers/vidcraft-server/server.py
@@ -802,7 +802,7 @@ def validate_structure(
 
 
 # Platform character limits
-_PLATFORM_LIMITS = {
+_PLATFORM_LIMITS: dict[str, dict[str, Any]] = {
     "heygen": {
         "max_chars_per_scene": 5000,
         "max_scenes": 100,

--- a/tools/analysis/document_parser.py
+++ b/tools/analysis/document_parser.py
@@ -157,7 +157,7 @@ def _parse_docx(path: Path) -> ParsedDocument:
     except ImportError:
         raise ImportError("python-docx required: pip install python-docx")
 
-    doc = Document(path)
+    doc = Document(str(path))
     metadata: dict[str, Any] = {}
 
     if doc.core_properties:
@@ -173,7 +173,7 @@ def _parse_docx(path: Path) -> ParsedDocument:
     has_list = False
 
     for para in doc.paragraphs:
-        style_name = (para.style.name or "").lower()
+        style_name = ((para.style.name or "") if para.style else "").lower()
 
         # Detect headings
         if style_name.startswith("heading"):
@@ -441,7 +441,7 @@ def analyze_complexity(doc: ParsedDocument) -> dict[str, Any]:
 
     # Complexity score (0-100)
     complexity = 0
-    complexity += min(doc.total_words / 50, 30)  # Length factor
+    complexity += min(doc.total_words // 50, 30)  # Length factor
     complexity += code_sections * 10  # Code factor
     complexity += min(total_sections * 3, 20)  # Depth factor
     complexity += 10 if avg_section_words > 200 else 0  # Dense sections


### PR DESCRIPTION
## Summary

- Add `mypy` to `requirements-dev.txt`
- Add mypy CI step (`tools/ servers/ hooks/ --ignore-missing-imports`)
- Fix 6 type errors surfaced by first run:
  - `document_parser.py`: `Document(str(path))` — python-docx expects str, not Path
  - `document_parser.py`: Guard `para.style` None before accessing `.name`
  - `document_parser.py`: Integer division to keep `complexity` as int
  - `server.py`: Annotate `_PLATFORM_LIMITS` as `dict[str, dict[str, Any]]`

## Test plan

- [ ] CI passes (test 3.11/3.12/3.13 + mypy step green)
- [ ] `mypy tools/ servers/ hooks/ --ignore-missing-imports` reports no errors locally

Closes #48
Part of epic #51