### PR TITLE
chore: hygiene bundle — hooks/ in ruff, stderr for hook output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,11 @@ jobs:
 
       - name: Lint with ruff
         run: |
-          ruff check tools/ tests/ servers/
+          ruff check tools/ tests/ servers/ hooks/
 
       - name: Check formatting with ruff
         run: |
-          ruff format --check tools/ tests/ servers/
+          ruff format --check tools/ tests/ servers/ hooks/
 
       - name: Run tests with coverage
         run: |

--- a/hooks/validate_scene.py
+++ b/hooks/validate_scene.py
@@ -81,7 +81,7 @@ def main() -> None:
 
     if issues:
         for issue in issues:
-            print(issue)
+            sys.stderr.write(issue + "\n")
         # Exit 0 — hooks should warn, not block
         sys.exit(0)
 


### PR DESCRIPTION
## Summary

- Add `hooks/` to ruff check and format targets in CI
- Replace `print()` with `sys.stderr.write()` in `hooks/validate_scene.py` (ruff T201 finding)
- Note: `.coverage` and `htmlcov/` were already in `.gitignore`, `pip-audit` already in CI — no action needed

Stale branches (4 from the audit) were pruned from remote — 3 were already deleted, `feat/phase3-platform-polish` deleted in this session.

## Test plan

- [x] CI passes (ruff check now includes hooks/)
- [ ] `ruff check tools/ tests/ servers/ hooks/` passes locally

Closes #50
Part of epic #51