### PR TITLE
refactor: reduce heygen_format_script complexity to ~5 branches

### DIFF
--- a/servers/vidcraft-server/server.py
+++ b/servers/vidcraft-server/server.py
@@ -934,6 +934,56 @@ def get_platform_capabilities(platform: str) -> str:
     return _safe_json(info)
 
 
+_HEYGEN_AVATAR_POSITIONS = {
+    "avatar": "Avatar: Center, facing camera",
+    "screencast": "Avatar: Hidden (or small overlay bottom-right)",
+    "split": "Avatar: Left third, screencast right two-thirds",
+}
+
+
+def _format_heygen_scene(name: str, scene: dict[str, Any]) -> str:
+    """Build the formatted block string for a single HeyGen scene."""
+    narration = _convert_pauses_to_ssml(scene.get("narration", "").strip())
+    visual_type = scene.get("visual_type", "avatar")
+    visual_dir = scene.get("visual_direction", "").strip()
+    on_screen = scene.get("on_screen_text", "").strip()
+
+    block = [
+        f"=== Scene {scene.get('number', '?')}: {scene.get('title', name)} ===",
+        f"Type: {visual_type}",
+    ]
+
+    avatar_line = _HEYGEN_AVATAR_POSITIONS.get(visual_type)
+    if avatar_line:
+        block.append(avatar_line)
+
+    if visual_dir:
+        block.append(f"Background: {visual_dir[:100]}")
+    if on_screen:
+        block.append(f"Text Overlay: {on_screen}")
+    if "<break" in narration:
+        block.append(
+            "Note: SSML <break> tags require a Custom Voice "
+            "(voice clone, ElevenLabs, or OpenAI Voice). "
+            "Public HeyGen Voice Library ignores them silently."
+        )
+
+    block.append(f"\nScript:\n{narration}")
+    block.append(
+        f"\nChars: {len(narration)}/5000 (API limit) — AI Studio auto-splits at ~1000 chars/segment"
+    )
+    return "\n".join(block)
+
+
+def _collect_heygen_variables(scenes: dict[str, Any]) -> set[str]:
+    """Collect all {{variable}} placeholder names across narration and on_screen_text."""
+    variables: set[str] = set()
+    for scene in scenes.values():
+        for field in ("narration", "on_screen_text"):
+            variables.update(re.findall(r"\{\{(\w+)\}\}", scene.get(field, "")))
+    return variables
+
+
 @mcp.tool()
 def heygen_format_script(
     project_slug: str,
@@ -961,52 +1011,13 @@ def heygen_format_script(
     if not scenes:
         return "No scenes found."
 
-    blocks: list[str] = []
-    for name, scene in sorted(scenes.items(), key=lambda x: x[1].get("number", 0)):
-        narration = _convert_pauses_to_ssml(scene.get("narration", "").strip())
-        visual_type = scene.get("visual_type", "avatar")
-        visual_dir = scene.get("visual_direction", "").strip()
-        on_screen = scene.get("on_screen_text", "").strip()
-
-        block = [
-            f"=== Scene {scene.get('number', '?')}: {scene.get('title', name)} ===",
-            f"Type: {visual_type}",
-        ]
-
-        if visual_type == "avatar":
-            block.append("Avatar: Center, facing camera")
-        elif visual_type == "screencast":
-            block.append("Avatar: Hidden (or small overlay bottom-right)")
-        elif visual_type == "split":
-            block.append("Avatar: Left third, screencast right two-thirds")
-
-        if visual_dir:
-            block.append(f"Background: {visual_dir[:100]}")
-
-        if on_screen:
-            block.append(f"Text Overlay: {on_screen}")
-
-        if "<break" in narration:
-            block.append(
-                "Note: SSML <break> tags require a Custom Voice "
-                "(voice clone, ElevenLabs, or OpenAI Voice). "
-                "Public HeyGen Voice Library ignores them silently."
-            )
-
-        block.append(f"\nScript:\n{narration}")
-        block.append(
-            f"\nChars: {len(narration)}/5000 (API limit) — AI Studio auto-splits at ~1000 chars/segment"
-        )
-        blocks.append("\n".join(block))
-
+    blocks = [
+        _format_heygen_scene(name, scene)
+        for name, scene in sorted(scenes.items(), key=lambda x: x[1].get("number", 0))
+    ]
     output = "\n\n".join(blocks)
 
-    # Collect all {{variable}} placeholders across all scenes
-    all_vars: set[str] = set()
-    for scene in scenes.values():
-        for field in ("narration", "on_screen_text"):
-            all_vars.update(re.findall(r"\{\{(\w+)\}\}", scene.get(field, "")))
-
+    all_vars = _collect_heygen_variables(scenes)
     if all_vars:
         var_lines = [f"  - {{{{{v}}}}}" for v in sorted(all_vars)]
         output += (

--- a/tests/test_format_tools.py
+++ b/tests/test_format_tools.py
@@ -319,3 +319,82 @@ class TestHeyGenVariableExtraction:
         assert "=== Variables Found ===" not in result, (
             "No variable block should appear when script has no {{placeholders}}"
         )
+
+
+class TestFormatHeygenSceneHelper:
+    """Unit tests for the extracted _format_heygen_scene helper."""
+
+    def test_avatar_type_adds_center_position(self) -> None:
+        server = _load_server_module()
+        scene = {"number": 1, "title": "Intro", "narration": "Hello.", "visual_type": "avatar", "visual_direction": "", "on_screen_text": ""}
+        result = server._format_heygen_scene("01-intro", scene)
+        assert "Avatar: Center, facing camera" in result
+
+    def test_screencast_type_hides_avatar(self) -> None:
+        server = _load_server_module()
+        scene = {"number": 1, "title": "Demo", "narration": "Watch this.", "visual_type": "screencast", "visual_direction": "", "on_screen_text": ""}
+        result = server._format_heygen_scene("01-demo", scene)
+        assert "Avatar: Hidden" in result
+
+    def test_split_type_positions_avatar_left(self) -> None:
+        server = _load_server_module()
+        scene = {"number": 1, "title": "Split", "narration": "Left right.", "visual_type": "split", "visual_direction": "", "on_screen_text": ""}
+        result = server._format_heygen_scene("01-split", scene)
+        assert "Avatar: Left third" in result
+
+    def test_visual_dir_truncated_to_100_chars(self) -> None:
+        server = _load_server_module()
+        long_dir = "x" * 200
+        scene = {"number": 1, "title": "T", "narration": "N.", "visual_type": "avatar", "visual_direction": long_dir, "on_screen_text": ""}
+        result = server._format_heygen_scene("01", scene)
+        assert f"Background: {'x' * 100}" in result
+        assert "x" * 101 not in result
+
+    def test_on_screen_text_included(self) -> None:
+        server = _load_server_module()
+        scene = {"number": 1, "title": "T", "narration": "N.", "visual_type": "avatar", "visual_direction": "", "on_screen_text": "Click here"}
+        result = server._format_heygen_scene("01", scene)
+        assert "Text Overlay: Click here" in result
+
+    def test_break_tag_triggers_caveat(self) -> None:
+        server = _load_server_module()
+        scene = {"number": 1, "title": "T", "narration": 'Go.<break time="1s"/>Done.', "visual_type": "avatar", "visual_direction": "", "on_screen_text": ""}
+        result = server._format_heygen_scene("01", scene)
+        assert "Custom Voice" in result
+
+    def test_no_break_no_caveat(self) -> None:
+        server = _load_server_module()
+        scene = {"number": 1, "title": "T", "narration": "Simple narration.", "visual_type": "avatar", "visual_direction": "", "on_screen_text": ""}
+        result = server._format_heygen_scene("01", scene)
+        assert "Custom Voice" not in result
+
+
+class TestCollectHeygenVariablesHelper:
+    """Unit tests for the extracted _collect_heygen_variables helper."""
+
+    def test_collects_variables_from_narration(self) -> None:
+        server = _load_server_module()
+        scenes = {"s1": {"narration": "Hello {{first_name}}!", "on_screen_text": ""}}
+        result = server._collect_heygen_variables(scenes)
+        assert result == {"first_name"}
+
+    def test_collects_variables_from_on_screen_text(self) -> None:
+        server = _load_server_module()
+        scenes = {"s1": {"narration": "", "on_screen_text": "Welcome {{company}}"}}
+        result = server._collect_heygen_variables(scenes)
+        assert result == {"company"}
+
+    def test_deduplicates_across_scenes(self) -> None:
+        server = _load_server_module()
+        scenes = {
+            "s1": {"narration": "Hi {{name}}", "on_screen_text": ""},
+            "s2": {"narration": "Bye {{name}} and {{team}}", "on_screen_text": ""},
+        }
+        result = server._collect_heygen_variables(scenes)
+        assert result == {"name", "team"}
+
+    def test_returns_empty_set_when_no_variables(self) -> None:
+        server = _load_server_module()
+        scenes = {"s1": {"narration": "No vars here.", "on_screen_text": ""}}
+        result = server._collect_heygen_variables(scenes)
+        assert result == set()

--- a/tests/test_format_tools.py
+++ b/tests/test_format_tools.py
@@ -326,45 +326,94 @@ class TestFormatHeygenSceneHelper:
 
     def test_avatar_type_adds_center_position(self) -> None:
         server = _load_server_module()
-        scene = {"number": 1, "title": "Intro", "narration": "Hello.", "visual_type": "avatar", "visual_direction": "", "on_screen_text": ""}
+        scene = {
+            "number": 1,
+            "title": "Intro",
+            "narration": "Hello.",
+            "visual_type": "avatar",
+            "visual_direction": "",
+            "on_screen_text": "",
+        }
         result = server._format_heygen_scene("01-intro", scene)
         assert "Avatar: Center, facing camera" in result
 
     def test_screencast_type_hides_avatar(self) -> None:
         server = _load_server_module()
-        scene = {"number": 1, "title": "Demo", "narration": "Watch this.", "visual_type": "screencast", "visual_direction": "", "on_screen_text": ""}
+        scene = {
+            "number": 1,
+            "title": "Demo",
+            "narration": "Watch this.",
+            "visual_type": "screencast",
+            "visual_direction": "",
+            "on_screen_text": "",
+        }
         result = server._format_heygen_scene("01-demo", scene)
         assert "Avatar: Hidden" in result
 
     def test_split_type_positions_avatar_left(self) -> None:
         server = _load_server_module()
-        scene = {"number": 1, "title": "Split", "narration": "Left right.", "visual_type": "split", "visual_direction": "", "on_screen_text": ""}
+        scene = {
+            "number": 1,
+            "title": "Split",
+            "narration": "Left right.",
+            "visual_type": "split",
+            "visual_direction": "",
+            "on_screen_text": "",
+        }
         result = server._format_heygen_scene("01-split", scene)
         assert "Avatar: Left third" in result
 
     def test_visual_dir_truncated_to_100_chars(self) -> None:
         server = _load_server_module()
         long_dir = "x" * 200
-        scene = {"number": 1, "title": "T", "narration": "N.", "visual_type": "avatar", "visual_direction": long_dir, "on_screen_text": ""}
+        scene = {
+            "number": 1,
+            "title": "T",
+            "narration": "N.",
+            "visual_type": "avatar",
+            "visual_direction": long_dir,
+            "on_screen_text": "",
+        }
         result = server._format_heygen_scene("01", scene)
         assert f"Background: {'x' * 100}" in result
         assert "x" * 101 not in result
 
     def test_on_screen_text_included(self) -> None:
         server = _load_server_module()
-        scene = {"number": 1, "title": "T", "narration": "N.", "visual_type": "avatar", "visual_direction": "", "on_screen_text": "Click here"}
+        scene = {
+            "number": 1,
+            "title": "T",
+            "narration": "N.",
+            "visual_type": "avatar",
+            "visual_direction": "",
+            "on_screen_text": "Click here",
+        }
         result = server._format_heygen_scene("01", scene)
         assert "Text Overlay: Click here" in result
 
     def test_break_tag_triggers_caveat(self) -> None:
         server = _load_server_module()
-        scene = {"number": 1, "title": "T", "narration": 'Go.<break time="1s"/>Done.', "visual_type": "avatar", "visual_direction": "", "on_screen_text": ""}
+        scene = {
+            "number": 1,
+            "title": "T",
+            "narration": 'Go.<break time="1s"/>Done.',
+            "visual_type": "avatar",
+            "visual_direction": "",
+            "on_screen_text": "",
+        }
         result = server._format_heygen_scene("01", scene)
         assert "Custom Voice" in result
 
     def test_no_break_no_caveat(self) -> None:
         server = _load_server_module()
-        scene = {"number": 1, "title": "T", "narration": "Simple narration.", "visual_type": "avatar", "visual_direction": "", "on_screen_text": ""}
+        scene = {
+            "number": 1,
+            "title": "T",
+            "narration": "Simple narration.",
+            "visual_type": "avatar",
+            "visual_direction": "",
+            "on_screen_text": "",
+        }
         result = server._format_heygen_scene("01", scene)
         assert "Custom Voice" not in result
 


### PR DESCRIPTION
## Summary

- Extract `_format_heygen_scene(name, scene)` — per-scene block formatting (avatar/screencast/split branches, overlays, break-tag caveat)
- Extract `_collect_heygen_variables(scenes)` — collects `{{placeholder}}` names
- Replace if/elif avatar-layout chain with `_HEYGEN_AVATAR_POSITIONS` dict lookup
- `heygen_format_script` becomes a clean orchestrator (~5 branches, down from 14)
- Add 12 unit tests for both helpers in `test_format_tools.py`

Ruff C901/PLR0912: no violations after refactor.

## Test plan

- [ ] CI passes (512 tests grün)
- [ ] `ruff check servers/ --select C901,PLR0912` meldet keine Violations

Closes #53
Part of epic #51