### PR TITLE
chore(ci): add server.py size gate — warn at 2000 lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,16 @@ jobs:
         run: |
           mypy tools/ servers/ hooks/ --ignore-missing-imports
 
+      - name: Check server.py size
+        run: |
+          lines=$(wc -l < servers/vidcraft-server/server.py)
+          threshold=2000
+          if [ "$lines" -gt "$threshold" ]; then
+            echo "::error file=servers/vidcraft-server/server.py::server.py has $lines lines (threshold: $threshold). Time to split document-analysis tools into tools/analysis/server_tools.py"
+            exit 1
+          fi
+          echo "server.py size OK: $lines / $threshold lines"
+
       - name: Run tests with coverage
         run: |
           python -m pytest tests/ -v --cov=tools --cov=servers --cov-fail-under=70


### PR DESCRIPTION
## Summary

- CI-Step blockiert wenn `servers/vidcraft-server/server.py` > 2000 Zeilen
- Aktueller Stand: 1672 Zeilen (~16% Headroom)
- Fehler-Message enthält den nächsten Schritt: Document-Analysis-Tools nach `tools/analysis/server_tools.py` extrahieren

## When the gate fires

Natürlicher Split: Document-Analysis-Tools (Zeilen ~1245–1444, 5 Tools) in `tools/analysis/server_tools.py` extrahieren und via `mcp.add_tool()` registrieren — bereits vorbereitet durch `tools/analysis/`-Struktur (siehe #54).

## Test plan

- [ ] CI läuft durch (gate feuert nicht bei 1672 Zeilen)
- [ ] Manuell: `echo 2001 > /tmp/bigfile` simuliert Gate-Auslösung

Closes #52
Part of epic #51